### PR TITLE
fix typos

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,9 +15,9 @@ var parsers = regexes.map(function(obj) {
     
     if (!m) { return null; }
     
-    var familly = famRep ? famRep.replace('$1', m[1]) : m[1];
+    var family = famRep ? famRep.replace('$1', m[1]) : m[1];
     
-    var obj = new UserAgent(familly);
+    var obj = new UserAgent(family);
     obj.major = parseInt(majorVersionRep ? majorVersionRep : m[2]);
     obj.minor = m[3] ? parseInt(m[3]) : null;
     obj.patch = m[4] ? parseInt(m[4]) : null;


### PR DESCRIPTION
this patch fixes a typo in the spelling of family (was familly).
