### PR TITLE
fix import of yaml from python

### DIFF
--- a/py/ua_parser/user_agent_parser.py
+++ b/py/ua_parser/user_agent_parser.py
@@ -392,7 +392,7 @@ def GetFilters(user_agent_string, js_user_agent_string=None,
 
 
 # Build the list of user agent parsers from YAML
-yamlFile = open(os.path.join(ROOT_DIR, '../../regexes.yaml'))
+yamlFile = open(os.path.join(ROOT_DIR, '../regexes.yaml'))
 yaml = yaml.load(yamlFile)
 yamlFile.close()
 


### PR DESCRIPTION
in master

```
from ua_parser import user_agent_parser
```

fails after a normal install with python setup.py install because the location of the yaml file is wrong.  This fixes it.
