### PR TITLE
Fix java replacement strings edge case

### DIFF
--- a/java/src/main/java/ua_parser/DeviceParser.java
+++ b/java/src/main/java/ua_parser/DeviceParser.java
@@ -98,7 +98,7 @@ public class DeviceParser {
       String family = null;
       if (familyReplacement != null) {
         if (familyReplacement.contains("$1") && matcher.groupCount() >= 1 && matcher.group(1) != null) {
-          family = familyReplacement.replaceFirst("\\$1", matcher.group(1));
+          family = familyReplacement.replaceFirst("\\$1", Matcher.quoteReplacement(matcher.group(1)));
         } else {
           family = familyReplacement;
         }

--- a/java/src/main/java/ua_parser/UserAgentParser.java
+++ b/java/src/main/java/ua_parser/UserAgentParser.java
@@ -88,7 +88,7 @@ public class UserAgentParser {
 
       if (familyReplacement != null) {
         if (familyReplacement.contains("$1") && groupCount >= 1 && matcher.group(1) != null) {
-          family = familyReplacement.replaceFirst("\\$1", matcher.group(1));
+          family = familyReplacement.replaceFirst("\\$1", Matcher.quoteReplacement(matcher.group(1)));
         } else {
           family = familyReplacement;
         }


### PR DESCRIPTION
quotes the matched group in case they contain '$' or '\'
