### PR TITLE
Adding support for Baidu Explorer

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -143,7 +143,7 @@ user_agent_parsers:
     
   # Baidu Browser
   - regex: '(FlyFlow)/(\d+)\.(\d+)'
-    family_replacement: 'Baidu Browser'
+    family_replacement: 'Baidu Explorer'
 
   # Pingdom
   - regex: '(Pingdom.com_bot_version_)(\d+)\.(\d+)'


### PR DESCRIPTION
This is Baidu's new Android browser. FlyFlow was the code name for the project. Not sure how stable this regex will prove to be though.

http://thenextweb.com/asia/2012/09/03/china-baidu-android-browser/

I haven't added it to to the mobile browser list yet. Wanted to get reaction from the group first.
