### PR TITLE
playstation vita and portable now listed under devices

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -602,6 +602,12 @@ device_parsers:
     device_replacement: 'HP Veer'
 
   ##########
+  # PlayStation
+  ##########
+  - regex: '(PlayStation Portable)'
+  - regex: '(PlayStation Vita)'
+  
+  ##########
   # incomplete!
   # Kindle
   ##########


### PR DESCRIPTION
also kills a device false positive with the kindle fire since the vita also uses silk.
