### PR TITLE
error when passing undefined as an argument

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -12,6 +12,8 @@ var ua_parsers = regexes.user_agent_parsers.map(function(obj) {
       majorVersionRep = obj.v1_replacement;
 
   function parser(ua) {
+    if (!ua) { return null; }
+      
     var m = ua.match(regexp);
     
     if (!m) { return null; }


### PR DESCRIPTION
I have seen a few sites make this mistake by directly passing request.headers['user-agent'] as the argument and this causes an error
