### PR TITLE
Fix setup.py dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,6 @@
 #!/usr/bin/env python
 from setuptools import setup, find_packages
 
-dependencies = [
-    'pyyaml',
-]
-
-dependency_links = [
-]
-
 setup(
     name='ua_parser',
     version='1.0',
@@ -17,5 +10,8 @@ setup(
     packages = find_packages('py'),
     package_dir={'':'py'},
     include_package_data=True,
-    data_files=[('',['regexes.yaml'])]
+    data_files=[('',['regexes.yaml'])],
+    install_requires = [
+        'pyyaml',
+    ]
 )


### PR DESCRIPTION
The setup.py is incorrect and does not install the PyYaml dependency, this commit makes it setuptools-compliant.
