### PR TITLE
Fixed a broken unit test where the device family wasn't replacing the correct string pattern.

### DIFF
--- a/csharp/UAParser.ConsoleApp/UAParser.ConsoleApp.csproj
+++ b/csharp/UAParser.ConsoleApp/UAParser.ConsoleApp.csproj
@@ -46,11 +46,10 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="YamlDotNet.Core">
-      <HintPath>..\packages\YamlDotNet.Core.1.1.15\lib\YamlDotNet.Core.dll</HintPath>
+      <HintPath>..\packages\YamlDotNet.Core.1.1.17\lib\YamlDotNet.Core.dll</HintPath>
     </Reference>
-    <Reference Include="YamlDotNet.RepresentationModel, Version=0.2.4453.29939, Culture=neutral, PublicKeyToken=2b53052c5884d7a1, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\YamlDotNet.RepresentationModel.1.1.15\lib\YamlDotNet.RepresentationModel.dll</HintPath>
+    <Reference Include="YamlDotNet.RepresentationModel">
+      <HintPath>..\packages\YamlDotNet.RepresentationModel.1.1.17\lib\YamlDotNet.RepresentationModel.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/csharp/UAParser.ConsoleApp/packages.config
+++ b/csharp/UAParser.ConsoleApp/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="YamlDotNet.Core" version="1.1.15" targetFramework="net40" />
-  <package id="YamlDotNet.RepresentationModel" version="1.1.15" targetFramework="net40" />
+  <package id="YamlDotNet.Core" version="1.1.17" targetFramework="net40" />
+  <package id="YamlDotNet.RepresentationModel" version="1.1.17" targetFramework="net40" />
 </packages>

--- a/csharp/UAParser.Tests/UAParser.Tests.csproj
+++ b/csharp/UAParser.Tests/UAParser.Tests.csproj
@@ -50,11 +50,10 @@
       <HintPath>..\packages\xunit.extensions.1.9.1\lib\net20\xunit.extensions.dll</HintPath>
     </Reference>
     <Reference Include="YamlDotNet.Core">
-      <HintPath>..\packages\YamlDotNet.Core.1.1.15\lib\YamlDotNet.Core.dll</HintPath>
+      <HintPath>..\packages\YamlDotNet.Core.1.1.17\lib\YamlDotNet.Core.dll</HintPath>
     </Reference>
-    <Reference Include="YamlDotNet.RepresentationModel, Version=0.2.4453.29939, Culture=neutral, PublicKeyToken=2b53052c5884d7a1, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\YamlDotNet.RepresentationModel.1.1.15\lib\YamlDotNet.RepresentationModel.dll</HintPath>
+    <Reference Include="YamlDotNet.RepresentationModel">
+      <HintPath>..\packages\YamlDotNet.RepresentationModel.1.1.17\lib\YamlDotNet.RepresentationModel.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/csharp/UAParser.Tests/packages.config
+++ b/csharp/UAParser.Tests/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="xunit" version="1.9.1" targetFramework="net40" />
   <package id="xunit.extensions" version="1.9.1" targetFramework="net40" />
-  <package id="YamlDotNet.Core" version="1.1.15" targetFramework="net40" />
-  <package id="YamlDotNet.RepresentationModel" version="1.1.15" targetFramework="net40" />
+  <package id="YamlDotNet.Core" version="1.1.17" targetFramework="net40" />
+  <package id="YamlDotNet.RepresentationModel" version="1.1.17" targetFramework="net40" />
 </packages>

--- a/csharp/UAParser/DevicePattern.cs
+++ b/csharp/UAParser/DevicePattern.cs
@@ -32,7 +32,7 @@ namespace UAParser
             {
                 if (m_familyReplacement.Contains("$1") && match.Groups.Count >= 1 && match.Groups[1] != null)
                 {
-                    family = m_familyReplacement.ReplaceFirstOccurence("\\$1", Regex.Escape(match.Groups[1].Value));
+                    family = m_familyReplacement.ReplaceFirstOccurence("$1", Regex.Escape(match.Groups[1].Value));
                 }
                 else
                 {

--- a/csharp/UAParser/UAParser.csproj
+++ b/csharp/UAParser/UAParser.csproj
@@ -46,10 +46,10 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="YamlDotNet.Core">
-      <HintPath>..\packages\YamlDotNet.Core.1.1.15\lib\YamlDotNet.Core.dll</HintPath>
+      <HintPath>..\packages\YamlDotNet.Core.1.1.17\lib\YamlDotNet.Core.dll</HintPath>
     </Reference>
     <Reference Include="YamlDotNet.RepresentationModel">
-      <HintPath>..\packages\YamlDotNet.RepresentationModel.1.1.15\lib\YamlDotNet.RepresentationModel.dll</HintPath>
+      <HintPath>..\packages\YamlDotNet.RepresentationModel.1.1.17\lib\YamlDotNet.RepresentationModel.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/csharp/UAParser/packages.config
+++ b/csharp/UAParser/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="YamlDotNet.Core" version="1.1.15" targetFramework="net40" />
-  <package id="YamlDotNet.RepresentationModel" version="1.1.15" targetFramework="net40" />
+  <package id="YamlDotNet.Core" version="1.1.17" targetFramework="net40" />
+  <package id="YamlDotNet.RepresentationModel" version="1.1.17" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Updated to latest YamlDotNet.Core
Fixed a broken unit test where the device family wasn't replacing the correct string pattern.
