### PR TITLE
Fix Python installation on Ubuntu

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 import os
 import shutil
-import sys
 
+from pkg_resources import resource_filename
 from setuptools import setup, find_packages
 from setuptools.command.install import install as _install
 
@@ -17,7 +17,7 @@ class install(_install):
         import yaml
         import ua_parser
         INSTALLATION_DIR = os.path.dirname(ua_parser.__file__)
-        source_path = os.path.join(sys.prefix, 'data', 'regexes.yaml')
+        source_path = resource_filename(__name__, 'regexes.yaml')
         destination_path = os.path.join(INSTALLATION_DIR,
                                         'regexes.yaml')
         shutil.move(source_path, destination_path)


### PR DESCRIPTION
On Ubuntu, `distutils` has been [patched](http://bazaar.launchpad.net/~ubuntu-branches/ubuntu/precise/python2.7/precise/view/head:/debian/patches/distutils-install-layout.diff) to, by default, use a different installation layout than is standard on Unix systems (to more closely follow FHS). As such, using `sys.prefix` to retrieve the location where data files are placed is not correct. This leads to installation failing as it can't access the regexes.yaml file.

To get around this, use the [`resource_filename`](http://peak.telecommunity.com/DevCenter/PythonEggs#accessing-package-resources) method provided by setuptools, which returns the correct location regardless of the platform.
