### PR TITLE
BREW updated, Pantech devices added, & Obigo standardized

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -175,7 +175,7 @@ user_agent_parsers:
   # Browser major_version.minor_version.beta_version (space instead of slash)
   - regex: '(iRider|Crazy Browser|SkipStone|iCab|Lunascape|Sleipnir|Maemo Browser) (\d+)\.(\d+)\.(\d+)'
   # Browser major_version.minor_version (space instead of slash)
-  - regex: '(iCab|Lunascape|Opera|Android|Jasmine|Polaris|BREW) (\d+)\.(\d+)\.?(\d+)?'
+  - regex: '(iCab|Lunascape|Opera|Android|Jasmine|Polaris) (\d+)\.(\d+)\.?(\d+)?'
   
   # Kindle WebKit
   - regex: '(Kindle)/(\d+)\.(\d+)'
@@ -512,6 +512,17 @@ os_parsers:
     os_replacement: 'BlackBerry Tablet OS'
   - regex: '(Black[Bb]erry)'
     os_replacement: 'Blackberry OS'
+
+  ##########
+  # BREW
+  # yes, Brew is lower-cased for Brew MP
+  ##########
+  - regex: '(BREW)[ /](\d+)\.(\d+)\.(\d+)'
+  - regex: '(BREW);'
+  - regex: '(Brew MP|BMP)[ /](\d+)\.(\d+)\.(\d+)'
+    os_replacement: 'Brew MP'
+  - regex: 'BMP;'
+    os_replacement: 'Brew MP'
 
   ##########
   # Google TV

--- a/test_resources/test_device.yaml
+++ b/test_resources/test_device.yaml
@@ -63,6 +63,12 @@ test_cases:
   - user_agent_string: 'Mozilla/5.0 (Linux; U; en-US) AppleWebKit/528.5+ (KHTML, like Gecko, Safari/528.5+) Version/4.0 Kindle/3.0 (screen 600x800; rotate)'
     family: 'Kindle'
 
+  - user_agent_string: 'NetFront/4.2 (BMP 1.0.4; U; en-us; LG; NetFront/4.2/AMB) Boost LG272 MMP/2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1'
+    family: 'LG 272'
+
+  - user_agent_string: 'Opera/9.80 (BREW; Opera Mini/5.1.191/27.2202; U; en) Presto/2.8.119 240X400 LG VN271'
+    family: 'LG VN271'
+
   - user_agent_string: 'Bunjalloo/0.7.6(Nintendo DS;U;en)'
     family: 'Nintendo DS'
     
@@ -95,6 +101,18 @@ test_cases:
 
   - user_agent_string: 'J2ME/UCWEB7.0.3.45/139/7682'
     family: 'Other'
+
+  - user_agent_string: 'Mozilla/4.0 (BREW 3.1.5; U; en-us; Sanyo; NetFront/3.5.1/AMB) Boost SCP3810'
+    family: 'Other'
+
+  - user_agent_string: 'Mozilla/4.0 (Brew MP 1.0.2; U; en-us; Sanyo; NetFront/3.5.1/AMB) Sprint E4100'
+    family: 'Other'
+
+  - user_agent_string: 'NetFront/3.5.1 (BREW 3.1.5; U; en-us; LG; NetFront/3.5.1/WAP) Sprint LN240 MMP/2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1'
+    family: 'Other'
+
+  - user_agent_string: 'PantechP6010/JNUS11072011 BMP/1.0.2 DeviceId/141020 NetFront/4.1 OMC/1.5.3 Profile/MIDP-2.1 Configuration/CLDC-1.1'
+    family: 'Pantech P6010'
 
   - user_agent_string: 'PantechP7040/JLUS04042011 Browser/Obigo/Q05A OMC/1.5.3 Profile/MIDP-2.1 Configuration/CLDC-1.1'
     family: 'Pantech P7040'

--- a/test_resources/test_user_agent_parser.yaml
+++ b/test_resources/test_user_agent_parser.yaml
@@ -340,6 +340,36 @@ test_cases:
     minor: '3'
     patch:
 
+  - user_agent_string: 'Mozilla/4.0 (BREW 3.1.5; U; en-us; Sanyo; NetFront/3.5.1/AMB) Boost SCP3810'
+    family: 'NetFront'
+    major: '3'
+    minor: '5'
+    patch: '1'
+
+  - user_agent_string: 'NetFront/3.5.1 (BREW 3.1.5; U; en-us; LG; NetFront/3.5.1/WAP) Sprint LN240 MMP/2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1'
+    family: 'NetFront'
+    major: '3'
+    minor: '5'
+    patch: '1'
+
+  - user_agent_string: 'Mozilla/4.0 (Brew MP 1.0.2; U; en-us; Sanyo; NetFront/3.5.1/AMB) Sprint E4100'
+    family: 'NetFront'
+    major: '3'
+    minor: '5'
+    patch: '1'
+
+  - user_agent_string: 'PantechP6010/JNUS11072011 BMP/1.0.2 DeviceId/141020 NetFront/4.1 OMC/1.5.3 Profile/MIDP-2.1 Configuration/CLDC-1.1'
+    family: 'NetFront'
+    major: '4'
+    minor: '1'
+    patch:
+    
+  - user_agent_string: 'NetFront/4.2 (BMP 1.0.4; U; en-us; LG; NetFront/4.2/AMB) Boost LG272 MMP/2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1'
+    family: 'NetFront'
+    major: '4'
+    minor: '2'
+    patch:
+
   - user_agent_string: 'ALCATEL-OT510A/382 ObigoInternetBrowser/Q05A'
     family: 'Obigo'
     major:
@@ -352,6 +382,12 @@ test_cases:
     minor:
     patch:
 
+  - user_agent_string: 'Opera/9.80 (BREW; Opera Mini/5.1.191/27.2202; U; en) Presto/2.8.119 240X400 LG VN271'
+    family: 'Opera Mini'
+    major: '5'
+    minor: '1'
+    patch:
+         
   - user_agent_string: 'Opera/9.80 (Series 60; Opera Mini/6.24455/25.677; U; fr) Presto/2.5.25 Version/10.54'
     family: 'Opera Mini'
     major: '6'

--- a/test_resources/test_user_agent_parser_os.yaml
+++ b/test_resources/test_user_agent_parser_os.yaml
@@ -140,6 +140,48 @@ test_cases:
     patch: '0'
     patch_minor:
 
+  - user_agent_string: 'Opera/9.80 (BREW; Opera Mini/5.1.191/27.2202; U; en) Presto/2.8.119 240X400 LG VN271'
+    family: 'BREW'
+    major:
+    minor:
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/4.0 (BREW 3.1.5; U; en-us; Sanyo; NetFront/3.5.1/AMB) Boost SCP3810'
+    family: 'BREW'
+    major: '3'
+    minor: '1'
+    patch: '5'
+    patch_minor:
+
+  - user_agent_string: 'NetFront/3.5.1 (BREW 3.1.5; U; en-us; LG; NetFront/3.5.1/WAP) Sprint LN240 MMP/2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1'
+    family: 'BREW'
+    major: '3'
+    minor: '1'
+    patch: '5'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/4.0 (Brew MP 1.0.2; U; en-us; Sanyo; NetFront/3.5.1/AMB) Sprint E4100'
+    family: 'Brew MP'
+    major: '1'
+    minor: '0'
+    patch: '2'
+    patch_minor:
+
+  - user_agent_string: 'NetFront/4.2 (BMP 1.0.4; U; en-us; LG; NetFront/4.2/AMB) Boost LG272 MMP/2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1'
+    family: 'Brew MP'
+    major: '1'
+    minor: '0'
+    patch: '4'
+    patch_minor:
+
+  - user_agent_string: 'PantechP6010/JNUS11072011 BMP/1.0.2 DeviceId/141020 NetFront/4.1 OMC/1.5.3 Profile/MIDP-2.1 Configuration/CLDC-1.1'
+    family: 'Brew MP'
+    major: '1'
+    minor: '0'
+    patch: '2'
+    patch_minor:
+
   - user_agent_string: 'Mozilla/5.0 (X11; U; BSD Four; en-US) AppleWebKit/533.3 (KHTML, like Gecko) rekonq Safari/533.3'
     family: 'BSD'
     major:


### PR DESCRIPTION
I moved BREW from browsers into OS. Added support for Brew MP which is the latest edition. Added support for Pantech devices. Standardized Obigo so it always returns the same string.
