### PR TITLE
webOS related fixes

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -62,11 +62,8 @@ user_agent_parsers:
   - regex: '(Opera)/9.80.*Version/(\d+)\.(\d+)(?:\.(\d+))?'
 
   # Palm WebOS looks a lot like Safari.
-  - regex: '(webOSBrowser)/(\d+)\.(\d+)'
-  - regex: '(webOS)/(\d+)\.(\d+)'
-    family_replacement: 'webOSBrowser'
-  - regex: '(wOSBrowser).+TouchPad/(\d+)\.(\d+)'
-    family_replacement: 'webOS TouchPad'
+  - regex: '(hpw|web)OS/(\d+)\.(\d+)(?:\.(\d+))?'
+    family_replacement: 'webOS Browser'
 
   # LuaKit has no version info.
   # http://luakit.org/projects/luakit/
@@ -550,7 +547,7 @@ os_parsers:
   ##########
   # Misc mobile
   ##########
-  - regex: '(webOS|hpwOS)/(\d+)\.(\d+)(?:\.(\d+))?'
+  - regex: '(hpw|web)OS/(\d+)\.(\d+)(?:\.(\d+))?'
     os_replacement: 'webOS'
 
   ##########
@@ -706,8 +703,8 @@ device_parsers:
     device_replacement: 'Palm Pre'
   - regex: '(Pixi)/(\d+)\.(\d+)'
     device_replacement: 'Palm Pixi'
-  - regex: '(Touchpad)/(\d+)\.(\d+)'
-    device_replacement: 'HP Touchpad'
+  - regex: '(Touch[Pp]ad)/(\d+)\.(\d+)'
+    device_replacement: 'HP TouchPad'
   - regex: 'HPiPAQ([A-Za-z0-9]+)/(\d+).(\d+)'
     device_replacement: 'HP iPAQ $1'
   - regex: 'Palm([A-Za-z0-9]+)'

--- a/test_resources/test_device.yaml
+++ b/test_resources/test_device.yaml
@@ -27,6 +27,9 @@ test_cases:
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 3.0.1; en-us; GT-P7510 Build/HRI83) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13'
     family: 'GT-P7510'
 
+  - user_agent_string: 'Mozilla/5.0 (hp-tablet; Linux; hpwOS/3.0.5; U; en-US) AppleWebKit/534.6 (KHTML, like Gecko) wOSBrowser/234.83 Safari/534.6 TouchPad/1.0'
+    family: 'HP TouchPad'
+
   - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.2.2; en-gb; HTC Desire Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'
     family: 'HTC Desire'
 

--- a/test_resources/test_user_agent_parser.yaml
+++ b/test_resources/test_user_agent_parser.yaml
@@ -713,16 +713,22 @@ test_cases:
     patch:
 
   - user_agent_string: 'Mozilla/5.0 (hp-tablet; Linux; hpwOS/3.0.0; U; en-US) AppleWebKit/534.6 (KHTML, like Gecko) wOSBrowser/233.58 Safari/534.6 TouchPad/1.0'
-    family: 'webOS TouchPad'
-    major: '1'
+    family: 'webOS Browser'
+    major: '3'
     minor: '0'
-    patch:
+    patch: '0'
 
   - user_agent_string: 'Mozilla/5.0 (webOS/1.2; U; en-US) AppleWebKit/525.27.1 (KHTML, like Gecko) Version/1.0 Safari/525.27.1 Desktop/1.0'
-    family: 'webOSBrowser'
+    family: 'webOS Browser'
     major: '1'
     minor: '2'
     patch:
+        
+  - user_agent_string: 'Mozilla/5.0 (hp-tablet; Linux; hpwOS/3.0.5; U; en-US) AppleWebKit/534.6 (KHTML, like Gecko) wOSBrowser/234.83 Safari/534.6 TouchPad/1.0'
+    family: 'webOS Browser'
+    major: '3'
+    minor: '0'
+    patch: '5'
 
   - user_agent_string: 'Mozilla/5.0 (X11; U; Linux i686; nl-NL) AppleWebKit/534.3 (KHTML, like Gecko) WeTab-Browser Safari/534.3'
     family: 'WeTab'

--- a/test_resources/test_user_agent_parser_os.yaml
+++ b/test_resources/test_user_agent_parser_os.yaml
@@ -602,6 +602,13 @@ test_cases:
     patch: '0'
     patch_minor:
 
+  - user_agent_string: 'Mozilla/5.0 (hp-tablet; Linux; hpwOS/3.0.5; U; en-US) AppleWebKit/534.6 (KHTML, like Gecko) wOSBrowser/234.83 Safari/534.6 TouchPad/1.0'
+    family: 'webOS'
+    major: '3'
+    minor: '0'
+    patch: '5'
+    patch_minor:
+
   - user_agent_string: 'Mozilla/5.0 (X11; U; Linux i686; nl-NL) AppleWebKit/534.3 (KHTML, like Gecko) WeTab-Browser Safari/534.3'
     family: 'WeTab'
     major:


### PR DESCRIPTION
removing webOS TouchPad as a ua match. Making the webOS browser regex
match version numbers like the android matches. making sure TouchPad is
appropriately capitilized.
