### PR TITLE
Update Readme with link to Ruby gem

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -43,6 +43,13 @@ Contributing to the project, especially `regexes.yaml`, is both welcomed and enc
 
 That's it. If you don't feel comfortable forking the project or modifying the YAML you can also [submit an issue](https://github.com/tobie/ua-parser/issues) that includes the appropriate user agent string and the expected results of parsing.
 
+Other ua-parser Libraries
+-------------------------
+
+There are a few other libraries which make use of ua-parser's patterns. These include:
+
+* Ruby - [user_agent_parser](https://github.com/toolmantim/user_agent_parser)
+
 Usage :: [node.js][1]
 ---------------------
 ```js


### PR DESCRIPTION
Adds a section for #22 to mention other libraries which may be based upon, or use, the ua-parser patterns.
