### PR TITLE
Opera 14 / WebKit detection

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -61,6 +61,10 @@ user_agent_parsers:
   - regex: '(Opera Mini)/att/(\d+)\.(\d+)'
   - regex: '(Opera)/9.80.*Version/(\d+)\.(\d+)(?:\.(\d+))?'
 
+  # Opera 14 for Android uses a WebKit render engine.
+  - regex: '(?:Mobile Safari).*(OPR)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Opera Mobile'
+
   # Palm WebOS looks a lot like Safari.
   - regex: '(hpw|web)OS/(\d+)\.(\d+)(?:\.(\d+))?'
     family_replacement: 'webOS Browser'

--- a/test_resources/test_user_agent_parser.yaml
+++ b/test_resources/test_user_agent_parser.yaml
@@ -604,6 +604,12 @@ test_cases:
     minor: '53'
     patch:
 
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android; 4.1.2; GT-I9100 Build/000000) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1234.12 Mobile Safari/537.22 OPR/14.0.123.123'
+    family: 'Opera Mobile'
+    major: '14'
+    minor: '0'
+    patch: '123'
+
   - user_agent_string: 'SomethingWeNeverKnewExisted'
     family: 'Other'
     major:


### PR DESCRIPTION
Added detection for Opera Mobile on Android which uses the newly announced WebKit engine. This makes it detected as Chrome Mobile instead of Opera Mobile.

See http://my.opera.com/ODIN/blog/2013/03/05/opera-14-beta-for-android-is-out

I'm assuming that Opera for desktop will also include OPR/<major>.<minor>.<patch> in the user agent string but it might be to soon to add support for that.
