### PR TITLE
fix path to data dir

### DIFF
--- a/py/ua_parser/user_agent_parser.py
+++ b/py/ua_parser/user_agent_parser.py
@@ -25,6 +25,7 @@ import yaml
 
 
 ROOT_DIR = os.path.abspath(os.path.dirname(__file__))
+DATA_DIR = os.path.abspath(os.path.join(ROOT_DIR, '..', 'data'))
 
 
 class UserAgentParser(object):
@@ -380,8 +381,8 @@ UA_PARSER_YAML = os.getenv("UA_PARSER_YAML")
 regexes = None
 
 if not UA_PARSER_YAML:
-    yamlPath = os.path.join(ROOT_DIR, 'regexes.yaml')
-    json_path = os.path.join(ROOT_DIR, 'regexes.json')
+    yamlPath = os.path.join(DATA_DIR, 'regexes.yaml')
+    json_path = os.path.join(DATA_DIR, 'regexes.json')
 else:
     yamlFile = open(UA_PARSER_YAML)
     regexes = yaml.load(yamlFile)


### PR DESCRIPTION
when installed via pip, at least, regexes.yaml lives in 
.../lib/python2.7/site-packages/ua_parser-0.3.2-py2.7.egg/data,
but ROOT_DIR is .../lib/python2.7/site-packages/ua_parser-0.3.2-py2.7.egg/ua-parser.

this sets a DATA_DIR up top, and uses that, instead of ROOT_DIR,
to find regexes.{yaml,json}.
