### PR TITLE
pom.xml should explicitly declare target java vesion

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -29,6 +29,17 @@
         </includes>
       </testResource>
     </testResources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
   <dependencies>
     <dependency>


### PR DESCRIPTION
I had this problem:

```
[ERROR] /home/w/ua-parser/java/src/main/java/ua_parser/UserAgentParser.java:[31,20] generics are not supported in -source 1.3
[ERROR] (use -source 5 or higher to enable generics)
[ERROR] private final List<UAPattern> patterns;
[ERROR] 
```

My version of pom.xml add explicit declaration of target java version as 1.6 (can be changed to lower if needed)
