### PR TITLE
Update regexes for Google Mobile Adsbot and Magpie Crawler

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -760,6 +760,13 @@ device_parsers:
     device_replacement: 'AppleTV'
 
   ##########
+  # Catch the google mobile crawler before checking for iPhones.
+  ##########
+
+  - regex: 'AdsBot-Google-Mobile'
+    device_replacement: 'Spider'
+    
+  ##########
   # complete but probably catches spoofs
   # iSTUFF
   ##########
@@ -970,6 +977,6 @@ device_parsers:
   ##########
   # Spiders (this is hack...)
   ##########
-  - regex: '(bot|borg|google(^tv)|yahoo|slurp|msnbot|msrbot|openbot|archiver|netresearch|lycos|scooter|altavista|teoma|gigabot|baiduspider|blitzbot|oegp|charlotte|furlbot|http%20client|polybot|htdig|ichiro|mogimogi|larbin|pompos|scrubby|searchsight|seekbot|semanticdiscovery|silk|snappy|speedy|spider|voila|vortex|voyager|zao|zeal|fast\-webcrawler|converacrawler|dataparksearch|findlinks)'
+  - regex: '(bot|borg|google(^tv)|yahoo|slurp|msnbot|msrbot|openbot|archiver|netresearch|lycos|scooter|altavista|teoma|gigabot|baiduspider|blitzbot|oegp|charlotte|furlbot|http%20client|polybot|htdig|ichiro|mogimogi|larbin|pompos|scrubby|searchsight|seekbot|semanticdiscovery|silk|snappy|speedy|spider|voila|vortex|voyager|zao|zeal|fast\-webcrawler|converacrawler|dataparksearch|findlinks|crawler)'
     device_replacement: 'Spider'
 

--- a/test_resources/test_device.yaml
+++ b/test_resources/test_device.yaml
@@ -239,3 +239,9 @@ test_cases:
 
   - user_agent_string: 'Mozilla/4.0 WebTV/2.6 (compatible; MSIE 4.0)'
     family: 'WebTV'
+
+  - user_agent_string: 'AdsBot-Google-Mobile (+http://www.google.com/mobile/adsbot.html) Mozilla (iPhone; U; CPU iPhone OS 3 0 like Mac OS X) AppleWebKit (KHTML, like Gecko) Mobile Safari'
+    family: 'Spider'
+
+  - user_agent_string: 'magpie-crawler/1.1 (U; Linux amd64; en-GB; +http://www.brandwatch.net)'
+    family: 'Spider'


### PR DESCRIPTION
This close Issues #221 and #223.

Correctly identifies the Google Mobile Adsbot as a spider.
Also flags the magpie crawler as a spider.
