### PR TITLE
Make python tests pass.

### DIFF
--- a/py/ua_parser/user_agent_parser.py
+++ b/py/ua_parser/user_agent_parser.py
@@ -258,6 +258,9 @@ def ParseDevice(user_agent_string):
         if device:
             break
 
+    if device == None:
+        device = 'Other'
+
     return {
       'family': device
     }

--- a/py/ua_parser/user_agent_parser_test.py
+++ b/py/ua_parser/user_agent_parser_test.py
@@ -71,7 +71,7 @@ class ParseTest(unittest.TestCase):
         user_agent_string = 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.4; fr; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5,gzip(gfe),gzip(gfe)'
         expected = {
           'device': {
-            'family': None
+            'family': 'Other'
           },
           'os': {
             'family': 'Mac OS X',
@@ -196,15 +196,9 @@ class ParseTest(unittest.TestCase):
             if 'js_ua' in test_case:
                 kwds = eval(test_case['js_ua'])
 
-            # The python client has been returning None is the family doesn't match. This probably should be changed in the parser,
-            # but would break many existing clients. If we want to change the parser behavior, it's line 152 of the parser.
-            good_family = test_case['family']
-            if good_family == 'Other':
-                good_family = None
-
             # The expected results
             expected = {
-              'family': good_family
+              'family': test_case['family']
             }
 
             result = user_agent_parser.ParseDevice(user_agent_string, **kwds)


### PR DESCRIPTION
Have python client support v2_replacement and os_v1 and os_v2 replacement.

Python client uses the None value instead of 'Other' when the device isn't found. Make the test reflect that.

The probable correct fix is to make the parse return 'Other' in that case, but this would be a change to the behavior that others are probably depending on.
