### PR TITLE
Update regexes.yaml

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -88,7 +88,7 @@ user_agent_parsers:
     family_replacement: 'Swiftfox'
 
   # Rekonq
-  - regex: '(rekonq)/(\d+)\.(\d+) Safari'
+  - regex: '(rekonq)/(\d+)\.(\d+)\.?(\d+)? Safari'
     family_replacement: 'Rekonq'
   - regex: 'rekonq'
     family_replacement: 'Rekonq'
@@ -176,6 +176,10 @@ user_agent_parsers:
   # Mail.ru Amigo/Internet Browser (Chromium-based)
   - regex: '(Chrome)/(\d+)\.(\d+)\.(\d+).* MRCHROME'
     family_replacement: 'Mail.ru Chromium Browser'
+
+  # Midori (Chromium-based)
+  - regex: '(Midori)/(\d+).(\d+)'
+    family_replacement: 'Midori'
 
   #### END SPECIAL CASES TOP ####
 
@@ -580,7 +584,7 @@ os_parsers:
   ##########
   - regex: '(GoogleTV) (\d+)\.(\d+)\.(\d+)'
   # Old style
-  - regex: '(GoogleTV)\/\d+'
+  - regex: '(GoogleTV)/\d+'
 
   - regex: '(WebTV)/(\d+).(\d+)'
   


### PR DESCRIPTION
changes made to handle the following user agents

Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.21 (KHTML, like Gecko) rekonq/2.2.1 Safari/537.21
- details in issue #237

Mozilla/5.0 (X11; Linux) AppleWebKit/537.6 (KHTML, like Gecko) Chrome/18.0.1025.133 Safari/537.6 Midori/0.4
- detailed in issue #236, but there is more work to be done which is explained in the issue.
- google tv issue is detailed in issue #235
