### PR TITLE
GoogleTV "old-style" version may contain non digit characters

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -592,7 +592,7 @@ os_parsers:
   ##########
   - regex: '(GoogleTV) (\d+)\.(\d+)\.(\d+)'
   # Old style
-  - regex: '(GoogleTV)/\d+'
+  - regex: '(GoogleTV)/[\da-z]+'
 
   - regex: '(WebTV)/(\d+).(\d+)'
   

--- a/test_resources/additional_os_tests.yaml
+++ b/test_resources/additional_os_tests.yaml
@@ -49,6 +49,13 @@ test_cases:
     patch:
     patch_minor:
 
+  - user_agent_string: 'Mozilla/5.0 (X11; U: Linux i686; en-US) AppleWebKit/533.4 (KHTML, like Gecko) Chrome/5.0.375.127 Large Screen Safari/533.4 GoogleTV/b39389'
+    family: 'GoogleTV'
+    major:
+    minor:
+    patch:
+    patch_minor:
+
   - user_agent_string: 'Mozilla/5.0 (Linux; GoogleTV 4.0.4; LG Google TV Build/000000) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.77 Safari/534.24'
     family: 'GoogleTV'
     major: '4'


### PR DESCRIPTION
GoogleTV user-agents may end up with tokens such as "GoogleTV/b39389"
(the character of interest is the "b" in "b39389"). The parser that
detects the GoogleTV OS rather expects the version to be composed of
digits.

I replaced "\d+" with "[\da-z]+". This could perhaps be further
restricted as I have never seen examples of model versions that
contain but do not start with a non digit character, but I doubt
being a tad more flexible creates any false positive.

Test added along other GoogleTV tests in additional_os_tests.yaml
