### PR TITLE
Support for HbbTV browsers (EU and AU Standard for Connected TVs)

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1,9 +1,10 @@
 user_agent_parsers:
   #### SPECIAL CASES TOP ####
 
-  # Add HbbTV browsers (Browser in TVs, standardized in Europe and Australia)
-  - regex: '(HbbTV)/[0-9.]+ \(.*;.+; ?(.+) ?; ?(.+) ?;.*;\)'
-
+  # HbbTV standard defines what features the browser should understand.
+  # but it's like targeting "HTML5 browsers", effective browser support depends on the model
+  # See os_parsers if you want to target a specific TV
+  - regex: '(HbbTV)/(\d+)\.(\d+)\.(\d+) \('
 
   # must go before Firefox to catch SeaMonkey/Camino
   - regex: '(SeaMonkey|Camino)/(\d+)\.(\d+)\.?([ab]?\d+[a-z]*)'
@@ -403,8 +404,57 @@ user_agent_parsers:
     family_replacement: 'Python Requests'
 
 os_parsers:
-  # HbbTV Televisions (Smart TV standard for EU and AU)
-  - regex: 'HbbTV/[0-9.]+ \(.*; ?(.+) ?;.*;.*;.*;\)'
+  ##########
+  # HbbTV vendors
+  ##########
+
+  # starts with the easy one : Panasonic seems consistent across years, hope it will continue
+  #HbbTV/1.1.1 (;Panasonic;VIERA 2011;f.532;0071-0802 2000-0000;)
+  #HbbTV/1.1.1 (;Panasonic;VIERA 2012;1.261;0071-3103 2000-0000;)
+  #HbbTV/1.2.1 (;Panasonic;VIERA 2013;3.672;4101-0003 0002-0000;)
+  #- regex: 'HbbTV/\d+\.\d+\.\d+ \(;(Panasonic);VIERA ([0-9]{4});'
+
+  # Sony is consistent too but do not place year like the other
+  # Opera/9.80 (Linux armv7l; HbbTV/1.1.1 (; Sony; KDL32W650A; PKG3.211EUA; 2013;); ) Presto/2.12.362 Version/12.11
+  # Opera/9.80 (Linux mips; U;  HbbTV/1.1.1 (; Sony; KDL40HX751; PKG1.902EUA; 2012;);; en) Presto/2.10.250 Version/11.60
+  # Opera/9.80 (Linux mips; U;  HbbTV/1.1.1 (; Sony; KDL22EX320; PKG4.017EUA; 2011;);; en) Presto/2.7.61 Version/11.00
+  #- regex: 'HbbTV/\d+\.\d+\.\d+ \(; (Sony);.*;.*; ([0-9]{4});\)'
+
+
+  # LG is consistent too, but we need to add manually the year model
+  #Mozilla/5.0 (Unknown; Linux armv7l) AppleWebKit/537.1+ (KHTML, like Gecko) Safari/537.1+ HbbTV/1.1.1 ( ;LGE ;NetCast 4.0 ;03.20.30 ;1.0M ;)
+  #Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ HbbTV/1.1.1 ( ;LGE ;NetCast 3.0 ;1.0 ;1.0M ;)
+  - regex: 'HbbTV/\d+\.\d+\.\d+ \( ;(LG)E ;NetCast 4.0'
+    os_v1_replacement: '2013'
+  - regex: 'HbbTV/\d+\.\d+\.\d+ \( ;(LG)E ;NetCast 3.0'
+    os_v1_replacement: '2012'
+
+  # Samsung is on its way of normalizing their user-agent
+  # HbbTV/1.1.1 (;Samsung;SmartTV2013;T-FXPDEUC-1102.2;;) WebKit
+  # HbbTV/1.1.1 (;Samsung;SmartTV2013;T-MST12DEUC-1102.1;;) WebKit
+  # HbbTV/1.1.1 (;Samsung;SmartTV2012;;;) WebKit
+  # HbbTV/1.1.1 (;;;;;) Maple_2011
+  - regex: 'HbbTV/1.1.1 \(;;;;;\) Maple_2011'
+    os_replacement: 'Samsung'
+    os_v1_replacement: '2011'
+  # manage the two models of 2013
+  - regex: 'HbbTV/\d+\.\d+\.\d+ \(;(Samsung);SmartTV([0-9]{4});.*FXPDEUC'
+    os_v2_replacement: 'UE40F7000'
+  - regex: 'HbbTV/\d+\.\d+\.\d+ \(;(Samsung);SmartTV([0-9]{4});.*MST12DEUC'
+    os_v2_replacement: 'UE32F4500'
+  # generic Samsung (works starting in 2012)
+  #- regex: 'HbbTV/\d+\.\d+\.\d+ \(;(Samsung);SmartTV([0-9]{4});'
+
+  # Philips : not found any other way than a manual mapping
+  # Opera/9.80 (Linux mips; U; HbbTV/1.1.1 (; Philips; ; ; ; ) CE-HTML/1.0 NETTV/4.1.3 PHILIPSTV/1.1.1; en) Presto/2.10.250 Version/11.60
+  # Opera/9.80 (Linux mips ; U; HbbTV/1.1.1 (; Philips; ; ; ; ) CE-HTML/1.0 NETTV/3.2.1; en) Presto/2.6.33 Version/10.70
+  - regex: 'HbbTV/1.1.1 \(; (Philips);.*NETTV/4'
+    os_v1_replacement: '2013'
+  - regex: 'HbbTV/1.1.1 \(; (Philips);.*NETTV/3'
+    os_v1_replacement: '2012'
+
+  # generic HbbTV, hoping to catch manufacturer name (always after 2nd comma) and the first string that looks like a 2010-2020 year
+  - regex: 'HbbTV/\d+\.\d+\.\d+ \(.*; ?([a-zA-Z]+) ?;.*(201[0-9]).*\)'
 
   ##########
   # Android
@@ -446,7 +496,7 @@ os_parsers:
   # lots of ua strings have Windows NT 4.1 !?!?!?!? !?!? !? !????!?! !!! ??? !?!?! ?
   # (very) roughly ordered in terms of frequency of occurence of regex (win xp currently most frequent, etc)
   ##########
-  
+
   - regex: '(Windows (?:NT 5\.2|NT 5\.1))'
     os_replacement: 'Windows XP'
 

--- a/test_resources/test_device.yaml
+++ b/test_resources/test_device.yaml
@@ -261,6 +261,18 @@ test_cases:
   - user_agent_string: 'Opera/9.80 (Linux armv7l; HbbTV/1.1.1 (; Sony; KDL32W650A; PKG3.211EUA; 2013;); ) Presto/2.12.362 Version/12.11'
     family: 'HbbTV'
 
+  - user_agent_string: 'HbbTV/1.1.1 (;Panasonic;VIERA 2012;1.261;0071-3103 2000-0000;)'
+    family: 'HbbTV'
+
+  - user_agent_string: 'Mozilla/5.0 (Unknown; Linux armv7l) AppleWebKit/537.1+ (KHTML, like Gecko) Safari/537.1+ HbbTV/1.1.1 ( ;LGE ;NetCast 4.0 ;03.20.30 ;1.0M ;)'
+    family: 'HbbTV'
+
+  - user_agent_string: 'Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ HbbTV/1.1.1 ( ;LGE ;NetCast 3.0 ;1.0 ;1.0M ;)'
+    family: 'HbbTV'
+
+  - user_agent_string: 'Opera/9.80 (Linux armv7l; HbbTV/1.1.1 (; Sony; KDL32W650A; PKG3.211EUA; 2013;); ) Presto/2.12.362 Version/12.11'
+    family: 'HbbTV'
+
 # up market model
   - user_agent_string: 'HbbTV/1.1.1 (;Samsung;SmartTV2013;T-FXPDEUC-1102.2;;) WebKit'
     family: 'HbbTV'

--- a/test_resources/test_user_agent_parser.yaml
+++ b/test_resources/test_user_agent_parser.yaml
@@ -862,3 +862,14 @@ test_cases:
     minor: '7'
     patch: '4343'
 
+  - user_agent_string: 'HbbTV/1.1.1 (;Samsung;SmartTV2013;T-FXPDEUC-1102.2;;) WebKit'
+    family: 'HbbTV'
+    major: '1'
+    minor: '1'
+    patch: '1'
+
+  - user_agent_string: 'HbbTV/1.2.1 (;Panasonic;VIERA 2013;3.672;4101-0003 0002-0000;)'
+    family: 'HbbTV'
+    major: '1'
+    minor: '2'
+    patch: '1'

--- a/test_resources/test_user_agent_parser_os.yaml
+++ b/test_resources/test_user_agent_parser_os.yaml
@@ -864,3 +864,106 @@ test_cases:
     minor: 
     patch:
     patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Unknown; Linux armv7l) AppleWebKit/537.1+ (KHTML, like Gecko) Safari/537.1+ HbbTV/1.1.1 ( ;LGE ;NetCast 4.0 ;03.20.30 ;1.0M ;)'
+    family: 'LG'
+    major: '2013'
+    minor: 
+    patch:
+    patch_minor: 
+
+  - user_agent_string: 'Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ HbbTV/1.1.1 ( ;LGE ;NetCast 3.0 ;1.0 ;1.0M ;)'
+    family: 'LG'
+    major: '2012'
+    minor: 
+    patch:
+    patch_minor: 
+
+  - user_agent_string: 'Opera/9.80 (Linux armv7l; HbbTV/1.1.1 (; Sony; KDL32W650A; PKG3.211EUA; 2013;); ) Presto/2.12.362 Version/12.11'
+    family: 'Sony'
+    major: '2013'
+    minor: 
+    patch:
+    patch_minor: 
+
+  - user_agent_string: 'Opera/9.80 (Linux mips; U;  HbbTV/1.1.1 (; Sony; KDL40HX751; PKG1.902EUA; 2012;);; en) Presto/2.10.250 Version/11.60'
+    family: 'Sony'
+    major: '2012'
+    minor: 
+    patch:
+    patch_minor: 
+
+  - user_agent_string: 'Opera/9.80 (Linux mips; U;  HbbTV/1.1.1 (; Sony; KDL22EX320; PKG4.017EUA; 2011;);; en) Presto/2.7.61 Version/11.00'
+    family: 'Sony'
+    major: '2011'
+    minor: 
+    patch:
+    patch_minor:
+
+# up market model
+  - user_agent_string: 'HbbTV/1.1.1 (;Samsung;SmartTV2013;T-FXPDEUC-1102.2;;) WebKit'
+    family: 'Samsung'
+    major: '2013'
+    minor: 'UE40F7000'
+    patch:
+    patch_minor: 
+
+# mid-range model
+  - user_agent_string: 'HbbTV/1.1.1 (;Samsung;SmartTV2013;T-MST12DEUC-1102.1;;) WebKit'
+    family: 'Samsung'
+    major: '2013'
+    minor: 'UE32F4500'
+    patch:
+    patch_minor: 
+
+# no way to differentiate models
+  - user_agent_string: 'HbbTV/1.1.1 (;Samsung;SmartTV2012;;;) WebKit'
+    family: 'Samsung'
+    major: '2012'
+    minor: 
+    patch:
+    patch_minor: 
+
+  - user_agent_string: 'HbbTV/1.1.1 (;;;;;) Maple_2011'
+    family: 'Samsung'
+    major: '2011'
+    minor: 
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Opera/9.80 (Linux mips ; U; HbbTV/1.1.1 (; Philips; ; ; ; ) CE-HTML/1.0 NETTV/3.2.1; en) Presto/2.6.33 Version/10.70'
+    family: 'Philips'
+    major: '2012'
+    minor: 
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Opera/9.80 (Linux mips; U; HbbTV/1.1.1 (; Philips; ; ; ; ) CE-HTML/1.0 NETTV/4.1.3 PHILIPSTV/1.1.1; en) Presto/2.10.250 Version/11.60'
+    family: 'Philips'
+    major: '2013'
+    minor: 
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'HbbTV/1.1.1 (;Panasonic;VIERA 2011;f.532;0071-0802 2000-0000;)'
+    family: 'Panasonic'
+    major: '2011'
+    minor: 
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'HbbTV/1.1.1 (;Panasonic;VIERA 2012;1.261;0071-3103 2000-0000;)'
+    family: 'Panasonic'
+    major: '2012'
+    minor: 
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'HbbTV/1.2.1 (;Panasonic;VIERA 2013;3.672;4101-0003 0002-0000;)'
+    family: 'Panasonic'
+    major: '2013'
+    minor: 
+    patch:
+    patch_minor: 
+
+


### PR DESCRIPTION
Every year since 3 years, a dozen of TV model or so are released, each with its own capabilities. By chance the HbbTV standard has been adopted by European TV networks and manufacturers, and this standard also defines a part of the User-Agent.
I tested the 2 regexes I added on a dozen of model and is using it with TestSwarm

Example of User-Agent : 
Mozilla/5.0 (Unknown; Linux armv7l) AppleWebKit/537.1+ (KHTML, like Gecko) Safari/537.1+ HbbTV/1.1.1 ( ;LGE ;NetCast 4.0 ;03.20.30 ;1.0M ;)
HbbTV/1.1.1 (;Panasonic;VIERA 2012;1.261;0071-3103 2000-0000;)
Opera/9.80 (Linux armv7l;  HbbTV/1.1.1 (; Sony; KDL32W650A; PKG3.211EUA; 2013;); ) Presto/2.12.362 Version/12.11
