### PR TITLE
Accounts for "iPod touch" in iOS 7.

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -793,6 +793,7 @@ device_parsers:
   # cannot determine specific device type from ua string. (3g, 3gs, 4, etc)
   - regex: '(iPad) Simulator;'
   - regex: '(iPad);'
+  - regex: '(iPod) touch;'
   - regex: '(iPod);'
   - regex: '(iPhone) Simulator;'
   - regex: '(iPhone);'

--- a/test_resources/test_device.yaml
+++ b/test_resources/test_device.yaml
@@ -54,6 +54,9 @@ test_cases:
   - user_agent_string: 'Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_2 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8H7 Safari/6533.18.5'
     family: 'iPod'
 
+  - user_agent_string: 'Mozilla/5.0 (iPod touch; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/537.40 (KHTML, like Gecko) Version/6.0 Mobile/11A4400f Safari/8536.25'
+    family: 'iPod'
+
   - user_agent_string: 'Mozilla/4.0 (compatible; Linux 2.6.10) NetFront/3.3 Kindle/1.0 (screen 600x800)'
     family: 'Kindle'
 


### PR DESCRIPTION
iOS 7 adds "touch" to the end of iPod. This causes iPod touches running iOS 7 to appear as "Generic Smartphone". This should address that case.
