### PR TITLE
Support IE 11's minimal ua string.

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -395,6 +395,9 @@ user_agent_parsers:
   - regex: '([MS]?IE) (\d+)\.(\d+)'
     family_replacement: 'IE'
 
+  - regex: 'Trident(.*)rv.(\d+)\.(\d+)'
+    family_replacement: 'IE'
+
   - regex: '(python-requests)/(\d+)\.(\d+)'
     family_replacement: 'Python Requests'
 

--- a/test_resources/test_user_agent_parser.yaml
+++ b/test_resources/test_user_agent_parser.yaml
@@ -862,3 +862,8 @@ test_cases:
     minor: '7'
     patch: '4343'
 
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 6.3; Win64; x64; Trident/7.0; rv:11.0) like Gecko'
+    family: 'IE'
+    major: '11'
+    minor: '0'
+    patch:


### PR DESCRIPTION
Support IE 11's minimal ua string the previous added version was pulled from their builds and changed to:

```
Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv 11.0) like Gecko
```

So the only hint we have left is the `Trident` reference for their rendering engine.
