### PR TITLE
Brand Model

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -59,6 +59,8 @@ console.log(r.os.minor);             // -> "1"
 console.log(r.os.patch);             // -> null
 
 console.log(r.device.family);        // -> "iPhone"
+console.log(r.device.brand);         // -> "Apple"
+console.log(r.device.model);         // -> "iPhone"
 ```
 
 Note if you're only interested in one of the `ua`, `device` or `os` objects, you will getter better performance by using the more specific methods (`uaParser.parseUA`, `uaParser.parseOS` and `uaParser.parseDevice` respectively), e.g.:
@@ -103,7 +105,7 @@ print result_dict['os']
 # {'major': '5', 'patch_minor': None, 'minor': '1', 'family': 'iOS', 'patch': None}
 
 print result_dict['device']
-# {'family': 'iPhone'}
+# {'family': 'iPhone', 'brand': 'Apple', 'model': 'iPhone'}
 ```
 
 
@@ -207,36 +209,41 @@ Usage :: php
 require_once 'vendor/autoload.php';
 use UAParser\Parser;
 
-$ua = "Mozilla/5.0 (Macintosh; Intel Ma...";
+$ua = "Mozilla/5.0 (iPod; CPU iPhone OS 5_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Mobile/9B176";
 
 $parser = Parser::create();
 $result = $parser->parse($ua);
 
-print $result->ua->family;            // Safari
-print $result->ua->major;             // 6
-print $result->ua->minor;             // 0
-print $result->ua->patch;             // 2
-print $result->ua->toString();        // Safari 6.0.2
-print $result->ua->toVersion();       // 6.0.2
-
-print $result->os->family;            // Mac OS X
-print $result->os->major;             // 10
-print $result->os->minor;             // 7
-print $result->os->patch;             // 5
-print $result->os->patchMinor;        // [null]
-print $result->os->toString();        // Mac OS X 10.7.5
-print $result->os->toVersion();       // 10.7.5
-
-print $result->device->family;        // Other
-
-print $result->toString();            // Safari 6.0.2/Mac OS X 10.7.5
-print $result->uaOriginal;            // Mozilla/5.0 (Macintosh; Intel Ma...
+print $result->ua->family ."\n";        // Mobile Safari
+print $result->ua->major ."\n";         // 5
+print $result->ua->minor ."\n";         // 1
+print $result->ua->patch ."\n";         // 
+print $result->ua->toString() ."\n";    // Mobile Safari 5.1
+print $result->ua->toVersion() ."\n";   // 5.1
+    
+print $result->os->family ."\n";        // iOS
+print $result->os->major ."\n";         // 5
+print $result->os->minor ."\n";         // 
+print $result->os->patch ."\n";         // 
+print $result->os->patchMinor ."\n";    // 
+print $result->os->toString() ."\n";    // iOS 5.1
+print $result->os->toVersion() ."\n";   // 5.1
+    
+print $result->device->family ."\n";    // iPod
+print $result->device->brand ."\n";     // Apple
+print $result->device->model ."\n";     // iPod
+    
+print $result->toString() ."\n";        // Mobile Safari 5.1/iOS 5.1
+print $result->originalUserAgent ."\n"; // Mozilla/5.0 (iPod; CPU iPhone ...
 ```
 
 [More information is available in the README](https://github.com/tobie/ua-parser/tree/master/php) in the PHP directory
 
 Usage :: D
 -------------
+
+**NOTE: This parser does not yet support brand-model parsing of `regexes.yaml` and therefore relies on `regexes_outdated.yaml` file**
+
 ```d
 import UaParser;
 
@@ -269,6 +276,9 @@ void main() {
 
 Usage :: C#
 -------------
+
+**NOTE: This parser does not yet support brand-model parsing of `regexes.yaml` and therefore relies on `regexes_outdated.yaml` file**
+
 Install the NuGet package
 
 	Install-Package UAParser
@@ -321,12 +331,17 @@ print $r->os->minor;              # -> "1"
 print $r->os->patch;              # -> undef
 
 print $r->device->family;         # -> "iPhone"
+print $r->device->brand;          # -> "Apple"
+print $r->device->model;          # -> "iPhone"
 
-More information is available in the README in the perl directory
 ```
+[More information is available in the README](https://github.com/tobie/ua-parser/tree/master/perl)
 
 Usage :: Haskell
 ---------------
+
+**NOTE: This parser does not yet support brand-model parsing of `regexes.yaml` and therefore relies on `regexes_outdated.yaml` file**
+
 ```haskell
 {-
 
@@ -367,6 +382,8 @@ Please refer to Haddocks for more info; the API is pretty straightforward.
 
 Usage :: Go
 ------------
+
+**NOTE: This parser does not yet support brand-model parsing of `regexes.yaml` and therefore relies on `regexes_outdated.yaml` file**
 
 Install the package:
 

--- a/csharp/UAParser.Tests/UAParser.Tests.csproj
+++ b/csharp/UAParser.Tests/UAParser.Tests.csproj
@@ -76,7 +76,7 @@
     <EmbeddedResource Include="..\..\test_resources\pgts_browser_list.yaml">
       <Link>TestResources\pgts_browser_list.yaml</Link>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\..\test_resources\test_device.yaml">
+    <EmbeddedResource Include="..\..\test_resources\test_device_outdated.yaml">
       <Link>TestResources\test_device.yaml</Link>
     </EmbeddedResource>
     <EmbeddedResource Include="..\..\test_resources\test_user_agent_parser.yaml">

--- a/d/README.markdown
+++ b/d/README.markdown
@@ -1,6 +1,8 @@
 ua-parser
 =========
 
+**NOTE: This parser does not yet support brand-model parsing of `regexes.yaml` and therefore relies on `regexes_outdated.yaml` file**
+
 `ua-parser` is a multi-language port of [BrowserScope][1]'s [user agent string parser][2].
 
 The crux of the original parser--the data collected by [Steve Souders][3] over the years--has been extracted into a separate [YAML file][4] so as to be reusable _as is_ by implementations in other programming languages.

--- a/go/uaparser/README.md
+++ b/go/uaparser/README.md
@@ -1,6 +1,9 @@
 Usage
 ========
 
+**NOTE: This parser does not yet support brand-model parsing of `regexes.yaml` and therefore relies on `regexes_outdated.yaml` file**
+
+
     package main
 
     import (
@@ -10,7 +13,7 @@ Usage
 
     func main() {
       testStr := "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us; Silk/1.1.0-80) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16 Silk-Accelerated=true"
-      regexFile := "../../regexes.yaml"
+      regexFile := "../../regexes_outdated.yaml"
       parser := uaparser.New(regexFile)
       client := parser.Parse(testStr)
       fmt.Println(client.UserAgent.Family)  // "Amazon Silk"
@@ -24,6 +27,7 @@ Usage
       fmt.Println(client.Os.PatchMinor)     // ""
       fmt.Println(client.Device.Family)     // "Kindle Fire"
     }
+
 
 Testing
 ========

--- a/go/uaparser/device_test.go
+++ b/go/uaparser/device_test.go
@@ -15,7 +15,7 @@ func dvcInitTesting(file string) []map[string]string {
 	return testMap["test_cases"]
 }
 
-var dvcDefaultRegexFile string = "../../regexes.yaml"
+var dvcDefaultRegexFile string = "../../regexes_outdated.yaml"
 var dvcParser *Parser = nil
 
 func dvcInitParser(regexFile string) {
@@ -47,7 +47,7 @@ func dvcHelperTest(file string) bool {
 }
 
 func TestDevice(t *testing.T) {
-	if !dvcHelperTest("../../test_resources/test_device.yaml") {
+	if !dvcHelperTest("../../test_resources/test_device_outdated.yaml") {
 		t.Fail()
 	} else {
 		fmt.Println("PASS")

--- a/go/uaparser/os_test.go
+++ b/go/uaparser/os_test.go
@@ -15,7 +15,7 @@ func osInitTesting(file string) []map[string]string {
 	return testMap["test_cases"]
 }
 
-var osDefaultRegexFile string = "../../regexes.yaml"
+var osDefaultRegexFile string = "../../regexes_outdated.yaml"
 var osParser *Parser = nil
 
 func osInitParser(regexFile string) {

--- a/go/uaparser/user_agent_test.go
+++ b/go/uaparser/user_agent_test.go
@@ -15,7 +15,7 @@ func uaInitTesting(file string) []map[string]string {
 	return testMap["test_cases"]
 }
 
-var uaDefaultRegexFile string = "../../regexes.yaml"
+var uaDefaultRegexFile string = "../../regexes_outdated.yaml"
 var uaParser *Parser = nil
 
 func uaInitParser(regexFile string) {

--- a/haskell/regexes.yaml
+++ b/haskell/regexes.yaml
@@ -1,1 +1,0 @@
-../regexes.yaml

--- a/haskell/regexes_outdated.yaml
+++ b/haskell/regexes_outdated.yaml
@@ -1,0 +1,1 @@
+../regexes_outdated.yaml

--- a/haskell/src/Web/UAParser.hs
+++ b/haskell/src/Web/UAParser.hs
@@ -35,4 +35,4 @@ import           Web.UAParser.Core
 loadUAParser :: IO UAConfig
 loadUAParser = do
   dir <- getDataDir
-  loadConfig $ dir </> "regexes.yaml"
+  loadConfig $ dir </> "../regexes_outdated.yaml"

--- a/haskell/test/src/TestSuite.hs
+++ b/haskell/test/src/TestSuite.hs
@@ -45,7 +45,7 @@ main = do
 
 -------------------------------------------------------------------------------
 benchMain = do
-  conf <- loadConfig "../regexes.yaml"
+  conf <- loadConfig "../regexes_outdated.yaml"
   cases <- loadTests "test_user_agent_parser.yaml"
   cases2 <- loadTests "firefox_user_agent_strings.yaml"
   let allC = cases ++ cases2
@@ -74,7 +74,7 @@ testMain = T.defaultMain tests
 
 -------------------------------------------------------------------------------
 uaTests = buildTest $ do
-  conf <- loadConfig "../regexes.yaml"
+  conf <- loadConfig "../regexes_outdated.yaml"
   cases <- loadTests "test_user_agent_parser.yaml"
   cases2 <- loadTests "firefox_user_agent_strings.yaml"
   let allC = cases ++ cases2
@@ -106,7 +106,7 @@ testUAParser config UATC{..} = testCase tn $ do
 
 -------------------------------------------------------------------------------
 osTests = buildTest $ do
-  conf <- loadConfig "../regexes.yaml"
+  conf <- loadConfig "../regexes_outdated.yaml"
   cases <- loadTests "test_user_agent_parser_os.yaml"
   return $ testGroup "OS Parsing Tests" $ map (testOSParser conf) cases
 

--- a/js/lib/device.js
+++ b/js/lib/device.js
@@ -1,24 +1,35 @@
 exports.Device = Device
-function Device(family) {
+function Device(family, brand, model) {
   this.family = family || 'Other';
+  this.brand = brand || null;
+  this.model = model || null;
 }
 
 Device.prototype.toString = function() {
   return this.family;
 };
 
+function multiReplace(str, m) {
+  return str.replace(/\$(\d)/g, function(tmp, i) {
+    return m[i] || '';
+  });
+}
 
 exports.makeParser = function(regexes) {
   var parsers = regexes.map(function (obj) {
     var regexp = new RegExp(obj.regex),
-        deviceRep = obj.device_replacement;
+        deviceRep = obj.device_replacement,
+        brandRep = obj.brand_replacement,
+        modelRep = obj.model_replacement;
 
     function parser(str) {
       var m = str.match(regexp);
       if (!m) { return null; }
 
-      var family = deviceRep ? deviceRep.replace('$1', m[1]) : m[1];
-      return new Device(family);
+      var family = deviceRep ? multiReplace(deviceRep, m) : m[1];
+      var brand  = brandRep  ? multiReplace(brandRep, m)  : null;
+      var model  = modelRep  ? multiReplace(modelRep, m)  : m[1];
+      return new Device(family, brand, model);
     }
 
     return parser;

--- a/js/test/with_fixtures.js
+++ b/js/test/with_fixtures.js
@@ -55,7 +55,12 @@ function msg(name, actual, expected) {
     fixtures.forEach(function(f) {
       test(f.user_agent_string, function() {
         var device = uaParser.parse(f.user_agent_string).device;
+        fixFixture(f, ['family', 'brand', 'model']);
+        
         assert.strictEqual(device.family, f.family, msg('device.family', device.family, f.family));
+        assert.strictEqual(device.brand, f.brand, msg('device.brand', device.brand, f.brand));
+        assert.strictEqual(device.model, f.model, msg('device.model', device.model, f.model));
+        
       });
     });
   });

--- a/php/src/UAParser/AbstractParser.php
+++ b/php/src/UAParser/AbstractParser.php
@@ -102,13 +102,37 @@ abstract class AbstractParser
      * @param string $string
      * @return string
      */
-    protected function replaceString($regex, $key, $string)
+    protected function replaceString(array $regex, $key, $string)
     {
         if (!isset($regex[$key])) {
             return $string;
         }
 
         return str_replace('$1', $string, $regex[$key]);
+    }
+
+    /**
+     * @param array $regex
+     * @param string $key
+     * @param string $default
+     * @param array $matches
+     * @return string
+     */
+    protected function multiReplace(array $regex, $key, $default, array $matches)
+    {
+        if (!isset($regex[$key])) {
+            return $default;
+        }
+        
+        $replacement = preg_replace_callback(
+            "|\\$(?<key>\d)|",
+            function ($m) use ($matches){
+                return isset($matches[$m['key']]) ? $matches[$m['key']] : "";
+            },
+            $regex[$key]
+        );
+        
+        return empty($replacement) ? null : $replacement;
     }
 
     /**

--- a/php/src/UAParser/DeviceParser.php
+++ b/php/src/UAParser/DeviceParser.php
@@ -26,7 +26,10 @@ class DeviceParser extends AbstractParser
         list($regex, $matches) = $this->tryMatch($this->regexes['device_parsers'], $userAgent);
 
         if ($matches) {
-            $device->family = $this->replaceString($regex, 'device_replacement', $matches[1]);
+            $device->family = $this->multiReplace($regex, 'device_replacement', $matches[1], $matches);            
+            $device->brand  = $this->multiReplace($regex, 'brand_replacement' , null, $matches);
+            $deviceModelDefault = $matches[1] != 'Other' ? $matches[1] : null;
+            $device->model  = $this->multiReplace($regex, 'model_replacement' , $deviceModelDefault, $matches);
         }
 
         return $device;

--- a/php/src/UAParser/Result/Device.php
+++ b/php/src/UAParser/Result/Device.php
@@ -11,4 +11,9 @@ namespace UAParser\Result;
 
 class Device extends AbstractSoftware
 {
+    /** @var string */
+    public $brand;
+
+    /** @var string */
+    public $model;
 }

--- a/php/tests/UAParser/Tests/ParserTest.php
+++ b/php/tests/UAParser/Tests/ParserTest.php
@@ -35,10 +35,8 @@ class ParserTest extends AbstractParserTest
     {
         $resources = Finder::create()
             ->files()
-            ->name('test_device.yaml')
-            ->name('*os*.yaml')
-            ->notName('test_device.yaml')
-            ->notName('pgts_browser_list-orig.yaml');
+            ->name('additional_os_tests.yaml')
+            ->name('test_user_agent_parser_os.yaml');
 
         return static::createTestData($resources);
     }
@@ -47,10 +45,9 @@ class ParserTest extends AbstractParserTest
     {
         $resources = Finder::create()
             ->files()
-            ->name('*.yaml')
-            ->notName('*os*')
-            ->notName('test_device.yaml')
-            ->notName('pgts_browser_list-orig.yaml');
+            ->name('firefox_user_agent_strings.yaml')
+            ->name('pgts_browser_list.yaml')
+            ->name('test_user_agent_parser.yaml');
 
         return static::createTestData($resources);
     }
@@ -65,11 +62,12 @@ class ParserTest extends AbstractParserTest
     }
 
     /** @dataProvider getDeviceTestData */
-    public function testDeviceParsing($userAgent, array $jsUserAgent, $family)
+    public function testDeviceParsing($userAgent, array $jsUserAgent, $family, $major, $minor, $patch, $patchMinor, $brand, $model)
     {
         $result = $this->parser->parse($userAgent, $jsUserAgent);
-
         $this->assertSame($family, $result->device->family);
+        $this->assertSame($brand,  $result->device->brand);
+        $this->assertSame($model,  $result->device->model);
     }
 
     /** @dataProvider getOsTestData */
@@ -190,6 +188,8 @@ class ParserTest extends AbstractParserTest
             isset($testCase['minor']) ? $testCase['minor'] : null,
             isset($testCase['patch']) ? $testCase['patch'] : null,
             isset($testCase['patch_minor']) ? $testCase['patch_minor'] : null,
+            isset($testCase['brand']) ? $testCase['brand'] : null,
+            isset($testCase['model']) ? $testCase['model'] : null,
             $resource->getFilename()
         );
     }

--- a/py/ua_parser/user_agent_parser_test.py
+++ b/py/ua_parser/user_agent_parser_test.py
@@ -71,7 +71,9 @@ class ParseTest(unittest.TestCase):
         user_agent_string = 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.4; fr; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5,gzip(gfe),gzip(gfe)'
         expected = {
           'device': {
-            'family': 'Other'
+            'family': 'Other',
+            'brand': None,
+            'model': None
           },
           'os': {
             'family': 'Mac OS X',
@@ -198,15 +200,21 @@ class ParseTest(unittest.TestCase):
 
             # The expected results
             expected = {
-              'family': test_case['family']
+              'family': test_case['family'],
+              'brand': test_case['brand'],
+              'model': test_case['model']
             }
 
             result = user_agent_parser.ParseDevice(user_agent_string, **kwds)
             self.assertEqual(result, expected,
-                u"UA: {0}\n expected<{1}> != actual<{2}>".format(
+                u"UA: {0}\n expected<{1} {2} {3}> != actual<{4} {5} {6}>".format(
                     user_agent_string,
                     expected['family'],
-                    result['family']))
+                    expected['brand'],
+                    expected['model'],
+                    result['family'],
+                    result['brand'],
+                    result['model']))
 
 
 class GetFiltersTest(unittest.TestCase):

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -734,7 +734,22 @@ device_parsers:
   # incomplete!
   # multiple replacement placeholds i.e. ($1) ($2) help solve problem of single device with multiple representations in ua
   # e.g. HTC Dream S should parse to the same device as HTC_DreamS
+  # 
+  # Note: multiple replacement placeholders are possible now (at least with js). 
+  #
   ##########
+
+  ##########
+  # Acer
+  ##########
+  - regex: '; (Acer )(.+) Build'
+    device_replacement: '$1$2'
+    brand_replacement: 'Acer'
+    model_replacement: '$2'
+  - regex: '; (A\d{3}) Build'
+    device_replacement: '$1'
+    brand_replacement: 'Acer'
+    model_replacement: '$1'
 
   ##########
   # incomplete!
@@ -742,41 +757,146 @@ device_parsers:
   # http://en.wikipedia.org/wiki/List_of_HTC_phones
   # this is quickly getting unwieldy
   ##########
+  - regex: '; (Amaze)(_)(4G) Build/'
+    device_replacement: '$1$2$3'
+    brand_replacement: 'HTC'
+    model_replacement: '$1 $3'
   # example: Mozilla/5.0 (Linux; U; Android 2.3.2; fr-fr; HTC HD2 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   - regex: 'HTC ([A-Z][a-z0-9]+) Build'
     device_replacement: 'HTC $1'
+    brand_replacement: 'HTC'
+    model_replacement: '$1'
   # example: Mozilla/5.0 (Linux; U; Android 2.1; es-es; HTC Legend 1.23.161.1 Build/ERD79) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17,gzip
   - regex: 'HTC ([A-Z][a-z0-9 ]+) \d+\.\d+\.\d+\.\d+'
     device_replacement: 'HTC $1'
+    brand_replacement: 'HTC'
+    model_replacement: '$1'
   # example: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; HTC_Touch_Diamond2_T5353; Windows Phone 6.5.3.5)
   - regex: 'HTC_Touch_([A-Za-z0-9]+)'
     device_replacement: 'HTC Touch ($1)'
+    brand_replacement: 'HTC'
+    model_replacement: 'Touch $1'
   # should come after HTC_Touch
-  - regex: 'USCCHTC(\d+)'
-    device_replacement: 'HTC $1 (US Cellular)'
+  - regex: '(USCCHTC)(\d+)'
+    device_replacement: 'HTC $2 (US Cellular)'
+    brand_replacement: 'HTC'
+    model_replacement: '$1$2'
   - regex: 'Sprint APA(9292)'
     device_replacement: 'HTC $1 (Sprint)'
+    brand_replacement: 'HTC'
+    model_replacement: '$1'
   - regex: 'HTC ([A-Za-z0-9]+ [A-Z])'
     device_replacement: 'HTC $1'
-  - regex: 'HTC[-_/\s]([A-Za-z0-9]+)'
+    brand_replacement: 'HTC'
+    model_replacement: '$1'
+  - regex: 'HTC[ _/\-]([A-Za-z0-9]+)'
     device_replacement: 'HTC $1'
+    brand_replacement: 'HTC'
+    model_replacement: '$1'
   - regex: '(ADR[A-Za-z0-9]+)'
     device_replacement: 'HTC $1'
+    brand_replacement: 'HTC'
+    model_replacement: '$1'
   - regex: '(HTC)'
+    brand_replacement: 'HTC'
 
-  # Tesla Model S
-  - regex: '(QtCarBrowser)'
-    device_replacement: 'Tesla Model S'
+  # Huawei
+  - regex: '; ((?:HUAWEI|Huawei)[ \-]?)(.+) Build/'
+    device_replacement: '$1$2'
+    brand_replacement: 'Huawei'
+    model_replacement: '$2'
+  - regex: '; ([^U][^;]+) Build/Huawei(U[^\)]+)\)'
+    device_replacement: '$1'
+    brand_replacement: 'Huawei'
+    model_replacement: '$2'
+  - regex: '; ([^;]+) Build/Huawei'
+    device_replacement: '$1'
+    brand_replacement: 'Huawei'
+    model_replacement: '$1'
+  - regex: '; ([Uu])([89]\d{3}) Build/'
+    device_replacement: '$1$2'
+    brand_replacement: 'Huawei'
+    model_replacement: 'U$2'
 
-  # Samsung
-  - regex: '(SamsungSGHi560)'
-    device_replacement: 'Samsung SGHi560'
+  # LG
+  - regex: '; *(LG\-)([^/]+)(/.+) Build/'
+    device_replacement: '$1$2$3'
+    brand_replacement: 'LG'
+    model_replacement: '$2'
+  - regex: '; *(LG[ \-])(.+) Build/'
+    device_replacement: '$1$2'
+    brand_replacement: 'LG'
+    model_replacement: '$2'
+  - regex: '; (GT540|E[34][0-9]{2}|Nexus 4) Build/'
+    device_replacement: '$1'
+    brand_replacement: 'LG'
+    model_replacement: '$1'
+
+  # Motorola
+  - regex: '; (Motorola[ \-])(.+) Build/'
+    device_replacement: '$1$2'
+    brand_replacement: 'Motorola'
+    model_replacement: '$2'
+  - regex: '; (ME[58]\d{2}\+?|MB\d{3}\+?|MZ\d{3}\+?|XT\d{3}) Build/'
+    device_replacement: '$1'
+    brand_replacement: 'Motorola'
+    model_replacement: '$1'
 
   #########
-  # Ericsson - must come before nokia since they also use symbian
+  # Samsung Android Devices - regex need to before Android General Device Matching
+  #########
+  - regex: '; (SAMSUNG )([^\/]*)\/[^ ]* Build/'
+    device_replacement: '$1$2'
+    brand_replacement: 'Samsung'
+    model_replacement: '$2'
+  - regex: '; (Galaxy(?: Ace| Nexus| S II)?) Build/'
+    device_replacement: '$1'
+    brand_replacement: 'Samsung'
+    model_replacement: '$1'
+  - regex: '; (SAMSUNG )(.+) Build/'
+    device_replacement: '$1$2'
+    brand_replacement: 'Samsung'
+    model_replacement: '$2'
+  - regex: '; (GT\-[BINPS]\d{4}[^\/]*)(\/[^ ]*) Build/'
+    device_replacement: '$1$2'
+    brand_replacement: 'Samsung'
+    model_replacement: '$1'
+  - regex: '; (GT\-[BINPS]\d{4}.*) Build/'
+    device_replacement: '$1'
+    brand_replacement: 'Samsung'
+    model_replacement: '$1'
+  - regex: '; (SPH-L710) Build/'
+    device_replacement: '$1'
+    brand_replacement: 'Samsung'
+    model_replacement: '$1'
+
+  #########
+  # SonyEricsson - must come before nokia since they also use symbian
   #########
   - regex: 'SonyEricsson([A-Za-z0-9]+)/'
     device_replacement: 'Ericsson $1'
+    brand_replacement: 'SonyEricsson'
+    model_replacement: '$1'
+  - regex: '; (SonyEricsson)([A-Za-z0-9\-]+) Build/'
+    device_replacement: '$1$2'
+    brand_replacement: '$1'
+    model_replacement: '$2'
+  - regex: '; ((?:ST|E|X|LT)\d{2}(?:i|i2)?|C6603) Build/'
+    device_replacement: '$1'
+    brand_replacement: 'SonyEricsson'
+    model_replacement: '$1'
+    
+  #########
+  # Sony
+  #########
+  - regex: '; (Sony)([A-Za-z0-9\-]+) Build/'
+    device_replacement: '$1$2'
+    brand_replacement: 'Sony'
+    model_replacement: '$2'
+  - regex: '; (SGP321) Build/'
+    device_replacement: '$1'
+    brand_replacement: 'Sony'
+    model_replacement: '$1'
 
   ##########
   # PlayStation
@@ -784,66 +904,183 @@ device_parsers:
   ##########
   - regex: 'PLAYSTATION 3'
     device_replacement: 'PlayStation 3'
-  - regex: '(PlayStation Portable)'
-  - regex: '(PlayStation Vita)'
+    brand_replacement: 'Sony'
+    model_replacement: 'PlayStation 3'
+  - regex: '(PlayStation (?:Portable|Vita))'
+    device_replacement: '$1'
+    brand_replacement: 'Sony'
+    model_replacement: '$1'
+
+  # Tesla Model S
+  - regex: '(QtCarBrowser)'
+    device_replacement: 'Tesla Model S'
+    brand_replacement: 'Tesla'
+    model_replacement: 'Model S'
+
+  # Tecno
+  - regex: '; *(TECNO[ _])(.+) Build/'
+    device_replacement: '$1$2'
+    brand_replacement: 'Tecno'
+    model_replacement: '$2'
+
+  #########
+  # ZTE
+  #########
+  - regex: '; (America|ARIZONA|Blade|Grand X .+|KIS PLUS|San Francisco II|Skate) Build/'
+    device_replacement: '$1'
+    brand_replacement: 'ZTE'
+    model_replacement: '$1'
+  - regex: '; (Orange |Optimus )(Monte Carlo|San Francisco) Build/'
+    device_replacement: '$1$2'
+    brand_replacement: 'ZTE'
+    model_replacement: '$1$2'
 
   ##########
-  # incomplete!
   # Kindle
-  # http://amazonsilk.wordpress.com/useful-bits/silk-user-agent/
+  # @note: Needs to be after Sony Playstation Vita as this UA contains Silk/3.2 
+  # @ref: https://developer.amazon.com/sdk/fire/specifications.html
+  # @ref: http://amazonsilk.wordpress.com/useful-bits/silk-user-agent/
   ##########
-  - regex: '(KFOT Build)'
+  - regex: '; ?(Kindle Fire) Build\b'
     device_replacement: 'Kindle Fire'
-  - regex: '(KFTT Build)'
+    brand_replacement: 'Amazon'
+    model_replacement: 'Kindle Fire'
+  - regex: '; ?(KFOT|KFOTE|Amazon Kindle Fire2) Build\b'
+    device_replacement: 'Kindle Fire 2'
+    brand_replacement: 'Amazon'
+    model_replacement: 'Kindle Fire 2'
+  - regex: '; ?(KFTT) Build\b'
     device_replacement: 'Kindle Fire HD'
-  - regex: '(KFJWI Build)'
+    brand_replacement: 'Amazon'
+    model_replacement: 'Kindle Fire HD 7"'
+  - regex: '; ?(KFJWI) Build\b'
     device_replacement: 'Kindle Fire HD 8.9" WiFi'
-  - regex: '(KFJWA Build)'
+    brand_replacement: 'Amazon'
+    model_replacement: 'Kindle Fire HD 8.9" WiFi'
+  - regex: '; ?(KFJWA) Build\b'
     device_replacement: 'Kindle Fire HD 8.9" 4G'
-  - regex: '(KFSOWI Build)'
+    brand_replacement: 'Amazon'
+    model_replacement: 'Kindle Fire HD 8.9" 4G'
+  - regex: '; ?(KFSOWI) Build\b'
     device_replacement: 'Kindle Fire HD 7" WiFi'
-  - regex: '(KFTHWI Build)'
+    brand_replacement: 'Amazon'
+    model_replacement: 'Kindle Fire HD 7" WiFi'
+  - regex: '; ?(KFTHWI) Build\b'
     device_replacement: 'Kindle Fire HDX 7" WiFi'
-  - regex: '(KFTHWA Build)'
+    brand_replacement: 'Amazon'
+    model_replacement: 'Kindle Fire HDX 7" WiFi'
+  - regex: '; ?(KFTHWA) Build\b'
     device_replacement: 'Kindle Fire HDX 7" 4G'
-  - regex: '(KFAPWI Build)'
+    brand_replacement: 'Amazon'
+    model_replacement: 'Kindle Fire HDX 7" 4G'
+  - regex: '; ?(KFAPWI) Build\b'
     device_replacement: 'Kindle Fire HDX 8.9" WiFi'
-  - regex: '(KFAPWA Build)'
+    brand_replacement: 'Amazon'
+    model_replacement: 'Kindle Fire HDX 8.9" WiFi'
+  - regex: '; ?(KFAPWA) Build\b'
     device_replacement: 'Kindle Fire HDX 8.9" 4G'
-  - regex: '(Kindle Fire)'
-  - regex: '(Kindle)'
-  - regex: '(Silk)/(\d+)\.(\d+)(?:\.([0-9\-]+))?'
+    brand_replacement: 'Amazon'
+    model_replacement: 'Kindle Fire HDX 8.9" 4G'
+  - regex: '; ?Amazon ([^;/]+) Build\b'
+    device_replacement: '$1'
+    brand_replacement: 'Amazon'
+    model_replacement: '$1'
+  - regex: '; ?(Kindle) Build\b'
+    device_replacement: 'Kindle'
+    brand_replacement: 'Amazon'
+    model_replacement: 'Kindle'
+  - regex: '; ?(Silk)/(\d+)\.(\d+)(?:\.([0-9\-]+))? Build\b'
     device_replacement: 'Kindle Fire'
-      
+    brand_replacement: 'Amazon'
+    model_replacement: 'Kindle Fire$2'
+  - regex: ' (Kindle)/(\d+\.\d+)'
+    device_replacement: 'Kindle'
+    brand_replacement: 'Amazon'
+    model_replacement: '$1 $2'
+  - regex: ' (Silk|Kindle)/(\d+)\.'
+    device_replacement: 'Kindle'
+    brand_replacement: 'Amazon'
+    model_replacement: 'Kindle'
+
+  #########
+  # Devices from chinese manufacturer(s)
+  # identified by x-wap-profile http://218.249.47.94/Xianghe/.*
+  #########
+  - regex: '; (Cynus F3|Cynus T[125]) Build/'
+    device_replacement: '$1'
+    brand_replacement: 'Mobistel'
+    model_replacement: '$1'
+  - regex: '; (SP\-100|SP\-140|SP\-140 DC|SP\-360|SPX\-12|SPX_8|SX7\-PEARL\.GmbH) Build/'
+    device_replacement: '$1'
+    brand_replacement: 'Simvalley'
+    model_replacement: '$1'
+  - regex: '; (Micromax )(.+) Build/'
+    device_replacement: '$1$2'
+    brand_replacement: 'Micromax'
+    model_replacement: '$2'
+  - regex: '; (H2000\+) Build/'
+    device_replacement: '$1'
+    brand_replacement: 'Hero'
+    model_replacement: '$1'
+  - regex: '; (iphone|iPhone5) Build'
+    device_replacement: 'Xianghe $1'
+    brand_replacement: 'Xianghe'
+    model_replacement: '$1'
+
   #########
   # Android General Device Matching (far from perfect)
   #########
   - regex: 'Android[\- ][\d]+\.[\d]+; [A-Za-z]{2}\-[A-Za-z]{0,2}; WOWMobile (.+) Build'
+    model_replacement: '$1'
   - regex: 'Android[\- ][\d]+\.[\d]+\-update1; [A-Za-z]{2}\-[A-Za-z]{0,2}; (.+) Build'
-  - regex: 'Android[\- ][\d]+\.[\d]+\.[\d]+; [A-Za-z]{2}\-[A-Za-z]{0,2}; (.+) Build'
-  - regex: 'Android[\- ][\d]+\.[\d]+\.[\d]+;[A-Za-z]{2}\-[A-Za-z]{0,2};(.+) Build'
-  - regex: 'Android[\- ][\d]+\.[\d]+; [A-Za-z]{2}\-[A-Za-z]{0,2}; (.+) Build'
-  - regex: 'Android[\- ][\d]+\.[\d]+\.[\d]+; (.+) Build'
-  - regex: 'Android[\- ][\d]+\.[\d]+; (.+) Build'
+    model_replacement: '$1'
+  - regex: 'Android[\- ][\d]+(?:\.[\d]+){1,2}; *[A-Za-z]{2}\-[A-Za-z]{0,2}; *(.+) Build'
+    model_replacement: '$1'
+  - regex: 'Android[\- ][\d]+(?:\.[\d]+){1,2}; *[A-Za-z]{0,2}\-; *(.+) Build' 
+    model_replacement: '$1'
+  - regex: 'Android[\- ][\d]+(?:\.[\d]+){1,2}; *\-?[A-Za-z]{2}; *(.+) Build' 
+    model_replacement: '$1'
+  - regex: 'Android[\- ][\d]+(?:\.[\d]+){1,2}; (.+) Build'
+    model_replacement: '$1'
+
+  #########
+  # Samsung Bada Phones
+  #########
+  - regex: '; SAMSUNG\-([^/;]+).*; U; Bada/'
+    device_replacement: 'Samsung $1'
+    brand_replacement: 'Samsung'
+    model_replacement: '$1'
+  - regex: '^SAMSUNG\-([^/;]+).* Bada/'
+    device_replacement: 'Samsung $1'
+    brand_replacement: 'Samsung'
+    model_replacement: '$1'
 
   ##########
   # NOKIA
   # nokia NokiaN8-00 comes before iphone. sometimes spoofs iphone
   ##########
-  - regex: 'NokiaN([0-9]+)'
-    device_replacement: 'Nokia N$1'
-  - regex: 'NOKIA([A-Za-z0-9\v-]+)'
+  - regex: 'Nokia(N[0-9]+)([A-z_\-][A-z0-9_\-]*)'
     device_replacement: 'Nokia $1'
-  - regex: 'Nokia([A-Za-z0-9\v-]+)'
+    brand_replacement: 'Nokia'
+    model_replacement: '$1$2'
+  - regex: '(?:NOKIA|Nokia) *([A-Za-z0-9\-]+)'
     device_replacement: 'Nokia $1'
-  - regex: 'NOKIA ([A-Za-z0-9\-]+)'
-    device_replacement: 'Nokia $1'
-  - regex: 'Nokia ([A-Za-z0-9\-]+)'
-    device_replacement: 'Nokia $1'
+    brand_replacement: 'Nokia'
+    model_replacement: '$1'
   - regex: 'Lumia ([A-Za-z0-9\-]+)'
     device_replacement: 'Lumia $1'
-  - regex: 'Symbian'
-    device_replacement: 'Nokia'
+    brand_replacement: 'Nokia'
+    model_replacement: 'Lumia $1'
+  # UCWEB Browser on Symbian
+  - regex: '\(Symbian; U; S60 V5; [A-z]{2}\-[A-z]{2}; (SonyEricsson|Samsung|Nokia)(.+)\)'
+    device_replacement: '$1 $2'
+    brand_replacement: '$1'
+    model_replacement: '$2'
+  # Nokia Symbian  
+  - regex: '\(Symbian(?:/3)?; U; ([^;]+);'
+    device_replacement: 'Nokia $1'
+    brand_replacement: 'Nokia'
+    model_replacement: '$1'
 
   ##########
   # BlackBerry
@@ -851,33 +1088,52 @@ device_parsers:
   ##########
   - regex: 'BB10; ([A-Za-z0-9\- ]+)\)'
     device_replacement: 'BlackBerry $1'
-  - regex: '(PlayBook).+RIM Tablet OS'
+    brand_replacement: 'BlackBerry'
+    model_replacement: '$1'
+  - regex: 'PlayBook.+RIM Tablet OS'
     device_replacement: 'BlackBerry Playbook'
+    brand_replacement: 'BlackBerry'
+    model_replacement: 'Playbook'
   - regex: 'Black[Bb]erry ([0-9]+);'
     device_replacement: 'BlackBerry $1'
+    brand_replacement: 'BlackBerry'
+    model_replacement: '$1'
   - regex: 'Black[Bb]erry([0-9]+)'
     device_replacement: 'BlackBerry $1'
+    brand_replacement: 'BlackBerry'
+    model_replacement: '$1'
   - regex: 'Black[Bb]erry;'
     device_replacement: 'BlackBerry'
+    brand_replacement: 'BlackBerry'
 
   ##########
   # PALM / HP
   ##########
   # some palm devices must come before iphone. sometimes spoofs iphone in ua
-  - regex: '(Pre)/(\d+)\.(\d+)'
-    device_replacement: 'Palm Pre'
-  - regex: '(Pixi)/(\d+)\.(\d+)'
-    device_replacement: 'Palm Pixi'
-  - regex: '(Touch[Pp]ad)/(\d+)\.(\d+)'
-    device_replacement: 'HP TouchPad'
-  - regex: 'HPiPAQ([A-Za-z0-9]+)/(\d+).(\d+)'
-    device_replacement: 'HP iPAQ $1'
+  - regex: '(Pre|Pixi)/\d+\.\d+'
+    device_replacement: 'Palm $1'
+    brand_replacement: 'Palm'
+    model_replacement: '$1'
   - regex: 'Palm([A-Za-z0-9]+)'
     device_replacement: 'Palm $1'
+    brand_replacement: 'Palm'
+    model_replacement: '$1'
   - regex: 'Treo([A-Za-z0-9]+)'
     device_replacement: 'Palm Treo $1'
+    brand_replacement: 'Palm'
+    model_replacement: 'Treo $1'
   - regex: 'webOS.*(P160UNA)/(\d+).(\d+)'
     device_replacement: 'HP Veer'
+    brand_replacement: 'HP'
+    model_replacement: 'Veer'
+  - regex: '(Touch[Pp]ad)/\d+\.\d+'
+    device_replacement: 'HP TouchPad'
+    brand_replacement: 'HP'
+    model_replacement: 'TouchPad'
+  - regex: 'HPiPAQ([A-Za-z0-9]+)/\d+.\d+'
+    device_replacement: 'HP iPAQ $1'
+    brand_replacement: 'HP'
+    model_replacement: 'iPAQ $1'
 
   ##########
   # AppleTV
@@ -886,16 +1142,19 @@ device_parsers:
   ##########
   - regex: '(AppleTV)'
     device_replacement: 'AppleTV'
+    brand_replacement: 'Apple'
+    model_replacement: '$1'
 
   ##########
   # Catch the google mobile crawler before checking for iPhones.
   ##########
-
   - regex: 'AdsBot-Google-Mobile'
     device_replacement: 'Spider'
+    model_replacement: 'Spider'
    
   - regex: 'Googlebot-Mobile/(\d+).(\d+)'
     device_replacement: 'Spider'
+    model_replacement: 'Spider'
     
   ##########
   # complete but probably catches spoofs
@@ -903,218 +1162,315 @@ device_parsers:
   ##########
   # ipad and ipod must be parsed before iphone
   # cannot determine specific device type from ua string. (3g, 3gs, 4, etc)
-  - regex: '(iPad) Simulator;'
-  - regex: '(iPad);'
+  - regex: '(iPad|iPhone|iPod|iPod)(?:;| Simulator;)'
+    device_replacement: '$1'
+    brand_replacement: 'Apple'
+    model_replacement: '$1'
   - regex: '(iPod) touch;'
-  - regex: '(iPod);'
-  - regex: '(iPhone) Simulator;'
-  - regex: '(iPhone);'
+    device_replacement: '$1'
+    brand_replacement: 'Apple'
+    model_replacement: '$1'
 
   ##########
   # Acer
   ##########
   - regex: 'acer_([A-Za-z0-9]+)_'
     device_replacement: 'Acer $1'
-  - regex: 'acer_([A-Za-z0-9]+)_'
-    device_replacement: 'Acer $1'
+    brand_replacement: 'Acer'
+    model_replacement: '$1'
 
   ##########   
   # Alcatel
   ##########
-  - regex: 'ALCATEL-([A-Za-z0-9]+)'
+  - regex: '(?:ALCATEL|Alcatel)-([A-Za-z0-9\-]+)'
     device_replacement: 'Alcatel $1'
-  - regex: 'Alcatel-([A-Za-z0-9]+)'
-    device_replacement: 'Alcatel $1'
+    brand_replacement: 'Alcatel'
+    model_replacement: '$1'
 
   ##########
   # Amoi
   ##########
-  - regex: 'Amoi\-([A-Za-z0-9]+)'
+  - regex: '(?:Amoi|AMOI)\-([A-Za-z0-9]+)'
     device_replacement: 'Amoi $1'
-  - regex: 'AMOI\-([A-Za-z0-9]+)'
-    device_replacement: 'Amoi $1'
+    brand_replacement: 'Amoi'
+    model_replacement: '$1'
 
   ##########
-  # Amoi
+  # Asus
   ##########
-  - regex: 'Asus\-([A-Za-z0-9]+)'
+  - regex: '(?:Asus|ASUS)\-([A-Za-z0-9]+)'
     device_replacement: 'Asus $1'
-  - regex: 'ASUS\-([A-Za-z0-9]+)'
-    device_replacement: 'Asus $1'
+    brand_replacement: 'Asus'
+    model_replacement: '$1'
 
   ##########
   # Bird
   ##########
-  - regex: 'BIRD\-([A-Za-z0-9]+)'
+  - regex: 'BIRD[ \-\.]([A-Za-z0-9]+)'
     device_replacement: 'Bird $1'
-  - regex: 'BIRD\.([A-Za-z0-9]+)'
-    device_replacement: 'Bird $1'
-  - regex: 'BIRD ([A-Za-z0-9]+)'
-    device_replacement: 'Bird $1'
+    brand_replacement: 'Bird'
+    model_replacement: '$1'
 
   ##########
   # Dell
   ##########
   - regex: 'Dell ([A-Za-z0-9]+)'
     device_replacement: 'Dell $1'
+    brand_replacement: 'Dell'
+    model_replacement: '$1'
 
   ##########
   # DoCoMo
   ##########
   - regex: 'DoCoMo/2\.0 ([A-Za-z0-9]+)'
     device_replacement: 'DoCoMo $1'
+    brand_replacement: 'DoCoMo'
+    model_replacement: '$1'
   - regex: '([A-Za-z0-9]+)_W\;FOMA'
     device_replacement: 'DoCoMo $1'
+    brand_replacement: 'DoCoMo'
+    model_replacement: '$1'
   - regex: '([A-Za-z0-9]+)\;FOMA'
     device_replacement: 'DoCoMo $1'
+    brand_replacement: 'DoCoMo'
+    model_replacement: '$1'
 
   ##########
   # Huawei
   ##########
   - regex: 'Huawei([A-Za-z0-9]+)'
     device_replacement: 'Huawei $1'
+    brand_replacement: 'Huawei'
+    model_replacement: '$1'
   - regex: 'HUAWEI-([A-Za-z0-9]+)'
     device_replacement: 'Huawei $1'
+    brand_replacement: 'Huawei'
+    model_replacement: '$1'
   - regex: 'vodafone([A-Za-z0-9]+)'
     device_replacement: 'Huawei Vodafone $1'
+    brand_replacement: 'Huawei'
+    model_replacement: 'Vodafone $1'
 
   ##########
   # i-mate
   ##########
   - regex: 'i\-mate ([A-Za-z0-9]+)'
     device_replacement: 'i-mate $1'
+    brand_replacement: 'i-mate'
+    model_replacement: '$1'
 
   ##########
   # kyocera
   ##########
   - regex: 'Kyocera\-([A-Za-z0-9]+)'
     device_replacement: 'Kyocera $1'
+    brand_replacement: 'Kyocera'
+    model_replacement: '$1'
   - regex: 'KWC\-([A-Za-z0-9]+)'
     device_replacement: 'Kyocera $1'
+    brand_replacement: 'Kyocera'
+    model_replacement: '$1'
 
   ##########
   # lenovo
   ##########
-  - regex: 'Lenovo\-([A-Za-z0-9]+)'
+  - regex: 'Lenovo[_\-]([A-Za-z0-9]+)'
     device_replacement: 'Lenovo $1'
-  - regex: 'Lenovo_([A-Za-z0-9]+)'
-    device_replacement: 'Lenovo $1'
+    brand_replacement: 'Lenovo'
+    model_replacement: '$1'
 
   ##########
   # HbbTV (European and Australian standard)
   # written before the LG regexes, as LG is making HbbTV too
   ##########
+  - regex: '(HbbTV)/[0-9]+\.[0-9]+\.[0-9]+ \( *; *(LG)E *; *([^;]*) +;.*;.*;\)'
+    device_replacement: '$1'
+    brand_replacement: '$2'
+    model_replacement: '$3'
+  - regex: '(HbbTV)/[0-9]+\.[0-9]+\.[0-9]+ \( *; *([^;]+) *; *([^;]*) *;.*;'
+    device_replacement: '$1'
+    brand_replacement: '$2'
+    model_replacement: '$3'
+  - regex: '(HbbTV)/1\.1\.1 \(;;;;;\) Maple_2011'  
+    device_replacement: '$1'
+    brand_replacement: 'Samsung'
   - regex: '(HbbTV)/[0-9]+\.[0-9]+\.[0-9]+'
+    device_replacement: '$1'
 
   ##########
   # lg
   ##########
   - regex: 'LG/([A-Za-z0-9]+)'
     device_replacement: 'LG $1'
+    brand_replacement: 'LG'
+    model_replacement: '$1'
   - regex: 'LG-LG([A-Za-z0-9]+)'
     device_replacement: 'LG $1'
+    brand_replacement: 'LG'
+    model_replacement: '$1'
   - regex: 'LGE-LG([A-Za-z0-9]+)'
     device_replacement: 'LG $1'
+    brand_replacement: 'LG'
+    model_replacement: '$1'
   - regex: 'LGE VX([A-Za-z0-9]+)'
     device_replacement: 'LG $1'
+    brand_replacement: 'LG'
+    model_replacement: '$1'
   - regex: 'LG ([A-Za-z0-9]+)'
     device_replacement: 'LG $1'
+    brand_replacement: 'LG'
+    model_replacement: '$1'
   - regex: 'LGE LG\-AX([A-Za-z0-9]+)'
     device_replacement: 'LG $1'
+    brand_replacement: 'LG'
+    model_replacement: '$1'
   - regex: 'LG\-([A-Za-z0-9]+)'
     device_replacement: 'LG $1'
+    brand_replacement: 'LG'
+    model_replacement: '$1'
   - regex: 'LGE\-([A-Za-z0-9]+)'
     device_replacement: 'LG $1'
+    brand_replacement: 'LG'
+    model_replacement: '$1'
   - regex: 'LG([A-Za-z0-9]+)'
     device_replacement: 'LG $1'
+    brand_replacement: 'LG'
+    model_replacement: '$1'
 
   ##########
   # kin
   ##########
   - regex: '(KIN)\.One (\d+)\.(\d+)'
     device_replacement: 'Microsoft $1'
+    brand_replacement: 'Microsoft'
+    model_replacement: '$1'
   - regex: '(KIN)\.Two (\d+)\.(\d+)'
     device_replacement: 'Microsoft $1'
+    brand_replacement: 'Microsoft'
+    model_replacement: '$1'
 
   ##########
   # motorola
   ##########
-  - regex: '(Motorola)\-([A-Za-z0-9]+)'
+  - regex: 'Motorola\-([A-Za-z0-9]+)'
+    device_replacement: 'Motorola $1'
+    brand_replacement: 'Motorola'
+    model_replacement: '$1'
   - regex: 'MOTO\-([A-Za-z0-9]+)'
     device_replacement: 'Motorola $1'
-  - regex: 'MOT\-([A-Za-z0-9]+)'
+    brand_replacement: 'Motorola'
+    model_replacement: '$1'
+  - regex: 'MOT\-([A-z0-9][A-z0-9\-]*)'
     device_replacement: 'Motorola $1'
+    brand_replacement: 'Motorola'
+    model_replacement: '$1'
     
   ##########
   # nintendo
   ##########
-  - regex: '(Nintendo WiiU)'
+  - regex: 'Nintendo WiiU'
     device_replacement: 'Nintendo Wii U'
+    brand_replacement: 'Nintendo'
+    model_replacement: 'Wii U'
   - regex: 'Nintendo (DS|3DS|DSi|Wii);'
     device_replacement: 'Nintendo $1'
+    brand_replacement: 'Nintendo'
+    model_replacement: '$1'
 
   ##########
   # pantech
   ##########
   - regex: 'Pantech([A-Za-z0-9]+)'
     device_replacement: 'Pantech $1'
+    brand_replacement: 'Pantech'
+    model_replacement: '$1'
  
   ##########
   # philips
   ##########
   - regex: 'Philips([A-Za-z0-9]+)'
     device_replacement: 'Philips $1'
+    brand_replacement: 'Philips'
+    model_replacement: '$1'
   - regex: 'Philips ([A-Za-z0-9]+)'
     device_replacement: 'Philips $1'
+    brand_replacement: 'Philips'
+    model_replacement: '$1'
 
   ##########
   # Samsung
   ##########
-  - regex: 'SAMSUNG-([A-Za-z0-9\-]+)'
+  # Samsung Bada Devices
+  - regex: 'SAMSUNG-(GT-[A-Za-z0-9\-]+).*; Bada/'
     device_replacement: 'Samsung $1'
-  - regex: 'SAMSUNG\; ([A-Za-z0-9\-]+)'
+    brand_replacement: 'Samsung'
+    model_replacement: '$1'
+  - regex: 'SAMSUNG(?:-|\; )([A-Za-z0-9\-]+)'
     device_replacement: 'Samsung $1'
+    brand_replacement: 'Samsung'
+    model_replacement: '$1'
+  # Samsung Symbian Devices
+  - regex: '(Samsung)(SGH)(i[0-9]+)'
+    device_replacement: '$1 $2$3'
+    brand_replacement: '$1'
+    model_replacement: '$2-$3'
+  - regex: 'SymbianOS/9\.\d.* Samsung[/\-]([^;/]+)'
+    device_replacement: 'Samsung $1'
+    brand_replacement: 'Samsung'
+    model_replacement: '$1'
 
   ##########
   # Sega
   ##########
-  - regex: 'Dreamcast'
-    device_replacement: 'Sega Dreamcast'
+  - regex: '(Dreamcast)'
+    device_replacement: 'Sega $1'
+    brand_replacement: 'Sega'
+    model_replacement: '$1'
 
   ##########
   # Softbank
   ##########
-  - regex: 'Softbank/1\.0/([A-Za-z0-9]+)'
+  - regex: 'Softbank/[12]\.0/([A-Za-z0-9]+)'
     device_replacement: 'Softbank $1'
-  - regex: 'Softbank/2\.0/([A-Za-z0-9]+)'
-    device_replacement: 'Softbank $1'
+    brand_replacement: 'Softbank'
+    model_replacement: '$1'
 
   ##########
   # WebTV
   ##########
-  - regex: '(WebTV)/(\d+).(\d+)'
+  - regex: '(WebTV)/\d+.\d+'
+    model_replacement: '$1'
 
   ##########
   # Generic Smart Phone
   ##########
   - regex: '(hiptop|avantgo|plucker|xiino|blazer|elaine|up.browser|up.link|mmp|smartphone|midp|wap|vodafone|o2|pocket|mobile|pda)'
     device_replacement: "Generic Smartphone"
+    brand_replacement: 'Generic'
+    model_replacement: 'Smartphone'
 
   ##########
   # Generic Feature Phone
   ##########
-  - regex: '^(1207|3gso|4thp|501i|502i|503i|504i|505i|506i|6310|6590|770s|802s|a wa|acer|acs\-|airn|alav|asus|attw|au\-m|aur |aus |abac|acoo|aiko|alco|alca|amoi|anex|anny|anyw|aptu|arch|argo|bell|bird|bw\-n|bw\-u|beck|benq|bilb|blac|c55/|cdm\-|chtm|capi|comp|cond|craw|dall|dbte|dc\-s|dica|ds\-d|ds12|dait|devi|dmob|doco|dopo|el49|erk0|esl8|ez40|ez60|ez70|ezos|ezze|elai|emul|eric|ezwa|fake|fly\-|fly_|g\-mo|g1 u|g560|gf\-5|grun|gene|go.w|good|grad|hcit|hd\-m|hd\-p|hd\-t|hei\-|hp i|hpip|hs\-c|htc |htc\-|htca|htcg)'
+  - regex: '^(1207|3gso|4thp|501i|502i|503i|504i|505i|506i|6310|6590|770s|802s|a wa|acer|acs\-|airn|alav|asus|attw|au\-m|aur |aus |abac|acoo|aiko|alco|alca|amoi|anex|anny|anyw|aptu|arch|argo|bell|bird|bw\-n|bw\-u|beck|benq|bilb|blac|c55/|cdm\-|chtm|capi|comp|cond|craw|dall|dbte|dc\-s|dica|ds\-d|ds12|dait|devi|dmob|doco|dopo|dorado|el49|erk0|esl8|ez40|ez60|ez70|ezos|ezze|elai|emul|eric|ezwa|fake|fly\-|fly_|g\-mo|g1 u|g560|gf\-5|grun|gene|go.w|good|grad|hcit|hd\-m|hd\-p|hd\-t|hei\-|hp i|hpip|hs\-c|htc |htc\-|htca|htcg)'
     device_replacement: 'Generic Feature Phone'
   - regex: '^(htcp|htcs|htct|htc_|haie|hita|huaw|hutc|i\-20|i\-go|i\-ma|i230|iac|iac\-|iac/|ig01|im1k|inno|iris|jata|java|kddi|kgt|kgt/|kpt |kwc\-|klon|lexi|lg g|lg\-a|lg\-b|lg\-c|lg\-d|lg\-f|lg\-g|lg\-k|lg\-l|lg\-m|lg\-o|lg\-p|lg\-s|lg\-t|lg\-u|lg\-w|lg/k|lg/l|lg/u|lg50|lg54|lge\-|lge/|lynx|leno|m1\-w|m3ga|m50/|maui|mc01|mc21|mcca|medi|meri|mio8|mioa|mo01|mo02|mode|modo|mot |mot\-|mt50|mtp1|mtv |mate|maxo|merc|mits|mobi|motv|mozz|n100|n101|n102|n202|n203|n300|n302|n500|n502|n505|n700|n701|n710|nec\-|nem\-|newg|neon)'
     device_replacement: 'Generic Feature Phone'
+    brand_replacement: 'Generic'
+    model_replacement: 'Feature Phone'
   - regex: '^(netf|noki|nzph|o2 x|o2\-x|opwv|owg1|opti|oran|ot\-s|p800|pand|pg\-1|pg\-2|pg\-3|pg\-6|pg\-8|pg\-c|pg13|phil|pn\-2|pt\-g|palm|pana|pire|pock|pose|psio|qa\-a|qc\-2|qc\-3|qc\-5|qc\-7|qc07|qc12|qc21|qc32|qc60|qci\-|qwap|qtek|r380|r600|raks|rim9|rove|s55/|sage|sams|sc01|sch\-|scp\-|sdk/|se47|sec\-|sec0|sec1|semc|sgh\-|shar|sie\-|sk\-0|sl45|slid|smb3|smt5|sp01|sph\-|spv |spv\-|sy01|samm|sany|sava|scoo|send|siem|smar|smit|soft|sony|t\-mo|t218|t250|t600|t610|t618|tcl\-|tdg\-|telm|tim\-|ts70|tsm\-|tsm3|tsm5|tx\-9|tagt)'
     device_replacement: 'Generic Feature Phone'
+    brand_replacement: 'Generic'
+    model_replacement: 'Feature Phone'
   - regex: '^(talk|teli|topl|tosh|up.b|upg1|utst|v400|v750|veri|vk\-v|vk40|vk50|vk52|vk53|vm40|vx98|virg|vite|voda|vulc|w3c |w3c\-|wapj|wapp|wapu|wapm|wig |wapi|wapr|wapv|wapy|wapa|waps|wapt|winc|winw|wonu|x700|xda2|xdag|yas\-|your|zte\-|zeto|aste|audi|avan|blaz|brew|brvw|bumb|ccwa|cell|cldc|cmd\-|dang|eml2|fetc|hipt|http|ibro|idea|ikom|ipaq|jbro|jemu|jigs|keji|kyoc|kyok|libw|m\-cr|midp|mmef|moto|mwbp|mywa|newt|nok6|o2im|pant|pdxg|play|pluc|port|prox|rozo|sama|seri|smal|symb|treo|upsi|vx52|vx53|vx60|vx61|vx70|vx80|vx81|vx83|vx85|wap\-|webc|whit|wmlb|xda\-|xda_)'
     device_replacement: 'Generic Feature Phone'
+    brand_replacement: 'Generic'
+    model_replacement: 'Feature Phone'
 
   ##########
   # Spiders (this is hack...)
   ##########
   - regex: '(bingbot|bot|borg|google(^tv)|yahoo|slurp|msnbot|msrbot|openbot|archiver|netresearch|lycos|scooter|altavista|teoma|gigabot|baiduspider|blitzbot|oegp|charlotte|furlbot|http%20client|polybot|htdig|ichiro|mogimogi|larbin|pompos|scrubby|searchsight|seekbot|semanticdiscovery|silk|snappy|speedy|spider|voila|vortex|voyager|zao|zeal|fast\-webcrawler|converacrawler|dataparksearch|findlinks|crawler)'
     device_replacement: 'Spider'
+    model_replacement: 'Spider'
 

--- a/regexes_outdated.yaml
+++ b/regexes_outdated.yaml
@@ -1,0 +1,1120 @@
+user_agent_parsers:
+  #### SPECIAL CASES TOP ####
+
+  # HbbTV standard defines what features the browser should understand.
+  # but it's like targeting "HTML5 browsers", effective browser support depends on the model
+  # See os_parsers if you want to target a specific TV
+  - regex: '(HbbTV)/(\d+)\.(\d+)\.(\d+) \('
+
+  # must go before Firefox to catch SeaMonkey/Camino
+  - regex: '(SeaMonkey|Camino)/(\d+)\.(\d+)\.?([ab]?\d+[a-z]*)'
+
+  # Firefox
+  - regex: '(Pale[Mm]oon)/(\d+)\.(\d+)\.?(\d+)?'
+    family_replacement: 'Pale Moon (Firefox Variant)'
+  - regex: '(Fennec)/(\d+)\.(\d+)\.?([ab]?\d+[a-z]*)'
+    family_replacement: 'Firefox Mobile'
+  - regex: '(Fennec)/(\d+)\.(\d+)(pre)'
+    family_replacement: 'Firefox Mobile'
+  - regex: '(Fennec)/(\d+)\.(\d+)'
+    family_replacement: 'Firefox Mobile'
+  - regex: 'Mobile.*(Firefox)/(\d+)\.(\d+)'
+    family_replacement: 'Firefox Mobile'
+  - regex: '(Namoroka|Shiretoko|Minefield)/(\d+)\.(\d+)\.(\d+(?:pre)?)'
+    family_replacement: 'Firefox ($1)'
+  - regex: '(Firefox)/(\d+)\.(\d+)(a\d+[a-z]*)'
+    family_replacement: 'Firefox Alpha'
+  - regex: '(Firefox)/(\d+)\.(\d+)(b\d+[a-z]*)'
+    family_replacement: 'Firefox Beta'
+  - regex: '(Firefox)-(?:\d+\.\d+)?/(\d+)\.(\d+)(a\d+[a-z]*)'
+    family_replacement: 'Firefox Alpha'
+  - regex: '(Firefox)-(?:\d+\.\d+)?/(\d+)\.(\d+)(b\d+[a-z]*)'
+    family_replacement: 'Firefox Beta'
+  - regex: '(Namoroka|Shiretoko|Minefield)/(\d+)\.(\d+)([ab]\d+[a-z]*)?'
+    family_replacement: 'Firefox ($1)'
+  - regex: '(Firefox).*Tablet browser (\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'MicroB'
+  - regex: '(MozillaDeveloperPreview)/(\d+)\.(\d+)([ab]\d+[a-z]*)?'
+
+  # e.g.: Flock/2.0b2
+  - regex: '(Flock)/(\d+)\.(\d+)(b\d+?)'
+
+  # RockMelt
+  - regex: '(RockMelt)/(\d+)\.(\d+)\.(\d+)'
+
+  # e.g.: Fennec/0.9pre
+  - regex: '(Navigator)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Netscape'
+
+  - regex: '(Navigator)/(\d+)\.(\d+)([ab]\d+)'
+    family_replacement: 'Netscape'
+
+  - regex: '(Netscape6)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Netscape'
+
+  - regex: '(MyIBrow)/(\d+)\.(\d+)'
+    family_replacement: 'My Internet Browser'
+
+  # Opera will stop at 9.80 and hide the real version in the Version string.
+  # see: http://dev.opera.com/articles/view/opera-ua-string-changes/
+  - regex: '(Opera Tablet).*Version/(\d+)\.(\d+)(?:\.(\d+))?'
+  - regex: '(Opera)/.+Opera Mobi.+Version/(\d+)\.(\d+)'
+    family_replacement: 'Opera Mobile'
+  - regex: 'Opera Mobi'
+    family_replacement: 'Opera Mobile'
+  - regex: '(Opera Mini)/(\d+)\.(\d+)'
+  - regex: '(Opera Mini)/att/(\d+)\.(\d+)'
+  - regex: '(Opera)/9.80.*Version/(\d+)\.(\d+)(?:\.(\d+))?'
+
+  # Opera 14 for Android uses a WebKit render engine.
+  - regex: '(?:Mobile Safari).*(OPR)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Opera Mobile'
+
+  # Opera 15 for Desktop is similar to Chrome but includes an "OPR" Version string.
+  - regex: '(?:Chrome).*(OPR)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Opera'
+
+  # Palm WebOS looks a lot like Safari.
+  - regex: '(hpw|web)OS/(\d+)\.(\d+)(?:\.(\d+))?'
+    family_replacement: 'webOS Browser'
+
+  # LuaKit has no version info.
+  # http://luakit.org/projects/luakit/
+  - regex: '(luakit)'
+    family_replacement: 'LuaKit'
+    
+  # Snowshoe
+  - regex: '(Snowshoe)/(\d+)\.(\d+).(\d+)'
+
+  # Lightning (for Thunderbird)
+  # http://www.mozilla.org/projects/calendar/lightning/
+  - regex: '(Lightning)/(\d+)\.(\d+)\.?((?:[ab]?\d+[a-z]*)|(?:\d*))'
+
+  # Swiftfox
+  - regex: '(Firefox)/(\d+)\.(\d+)\.(\d+(?:pre)?) \(Swiftfox\)'
+    family_replacement: 'Swiftfox'
+  - regex: '(Firefox)/(\d+)\.(\d+)([ab]\d+[a-z]*)? \(Swiftfox\)'
+    family_replacement: 'Swiftfox'
+
+  # Rekonq
+  - regex: '(rekonq)/(\d+)\.(\d+)\.?(\d+)? Safari'
+    family_replacement: 'Rekonq'
+  - regex: 'rekonq'
+    family_replacement: 'Rekonq'
+
+  # Conkeror lowercase/uppercase
+  # http://conkeror.org/
+  - regex: '(conkeror|Conkeror)/(\d+)\.(\d+)\.?(\d+)?'
+    family_replacement: 'Conkeror'
+
+  # catches lower case konqueror
+  - regex: '(konqueror)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Konqueror'
+
+  - regex: '(WeTab)-Browser'
+
+  - regex: '(Comodo_Dragon)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Comodo Dragon'
+
+  # Bots
+  - regex: '(YottaaMonitor|BrowserMob|HttpMonitor|YandexBot|Slurp|BingPreview|PagePeeker|ThumbShotsBot|WebThumb|URL2PNG|ZooShot|GomezA|Catchpoint bot|Willow Internet Crawler|Google SketchUp|Read%20Later)'
+
+  - regex: '(Symphony) (\d+).(\d+)'
+
+  - regex: '(Minimo)'
+
+  # Chrome Mobile
+  - regex: '(CrMo)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Chrome Mobile'
+  - regex: '(CriOS)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Chrome Mobile iOS'
+  - regex: '(Chrome)/(\d+)\.(\d+)\.(\d+)\.(\d+) Mobile'
+    family_replacement: 'Chrome Mobile'
+
+  # Chrome Frame must come before MSIE.
+  - regex: '(chromeframe)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Chrome Frame'
+
+  # UC Browser
+  - regex: '(UCBrowser)[ /](\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'UC Browser'
+  - regex: '(UC Browser)[ /](\d+)\.(\d+)\.(\d+)'
+  - regex: '(UC Browser|UCBrowser|UCWEB)(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'UC Browser'
+
+  # Tizen Browser (second case included in browser/major.minor regex)
+  - regex: '(SLP Browser)/(\d+)\.(\d+)'
+    family_replacement: 'Tizen Browser'
+
+  # Sogou Explorer 2.X
+  - regex: '(SE 2\.X) MetaSr (\d+)\.(\d+)'
+    family_replacement: 'Sogou Explorer'
+
+  # Baidu Browsers (desktop spoofs chrome & IE, explorer is mobile)
+  - regex: '(baidubrowser)[/\s](\d+)'
+    family_replacement: 'Baidu Browser'
+  - regex: '(FlyFlow)/(\d+)\.(\d+)'
+    family_replacement: 'Baidu Explorer'
+
+  # Pingdom
+  - regex: '(Pingdom.com_bot_version_)(\d+)\.(\d+)'
+    family_replacement: 'PingdomBot'
+
+  # Facebook
+  - regex: '(facebookexternalhit)/(\d+)\.(\d+)'
+    family_replacement: 'FacebookBot'
+
+  # LinkedIn
+  - regex: '(LinkedInBot)/(\d+)\.(\d+)'
+    family_replacement: 'LinkedInBot'
+
+  # Twitterbot
+  - regex: '(Twitterbot)/(\d+)\.(\d+)'
+    family_replacement: 'TwitterBot'
+
+  # Rackspace Monitoring
+  - regex: '(Rackspace Monitoring)/(\d+)\.(\d+)'
+    family_replacement: 'RackspaceBot'
+
+  # PyAMF
+  - regex: '(PyAMF)/(\d+)\.(\d+)\.(\d+)'
+
+  # Yandex Browser
+  - regex: '(YaBrowser)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Yandex Browser'
+
+  # Mail.ru Amigo/Internet Browser (Chromium-based)
+  - regex: '(Chrome)/(\d+)\.(\d+)\.(\d+).* MRCHROME'
+    family_replacement: 'Mail.ru Chromium Browser'
+
+  # AOL Browser (IE-based)
+  - regex: '(AOL) (\d+)\.(\d+); AOLBuild (\d+)'
+
+
+
+
+  #### END SPECIAL CASES TOP ####
+
+  #### MAIN CASES - this catches > 50% of all browsers ####
+
+  # Browser/major_version.minor_version.beta_version
+  - regex: '(AdobeAIR|FireWeb|Jasmine|ANTGalio|Midori|Fresco|Lobo|PaleMoon|Maxthon|Lynx|OmniWeb|Dillo|Camino|Demeter|Fluid|Fennec|Epiphany|Shiira|Sunrise|Flock|Netscape|Lunascape|WebPilot|Vodafone|NetFront|Netfront|Konqueror|SeaMonkey|Kazehakase|Vienna|Iceape|Iceweasel|IceWeasel|Iron|K-Meleon|Sleipnir|Galeon|GranParadiso|Opera Mini|iCab|NetNewsWire|ThunderBrowse|Iris|UP\.Browser|Bunjalloo|Google Earth|Raven for Mac|Openwave)/(\d+)\.(\d+)\.(\d+)'
+
+  # Outlook 2007
+  - regex: 'MSOffice 12'
+    family_replacement: 'Outlook'
+    v1_replacement: '2007'
+
+  # Outlook 2010
+  - regex: 'MSOffice 14'
+    family_replacement: 'Outlook'
+    v1_replacement: '2010'
+
+  # Outlook 2013
+  - regex: 'Microsoft Outlook 15\.\d+\.\d+'
+    family_replacement: 'Outlook'
+    v1_replacement: '2013'
+
+  # Apple Air Mail
+  - regex: '(Airmail) (\d+)\.(\d+)(?:\.(\d+))?'
+
+  # Thunderbird
+  - regex: '(Thunderbird)/(\d+)\.(\d+)\.(\d+(?:pre)?)'
+    family_replacement: 'Thunderbird'
+
+  # Chrome/Chromium/major_version.minor_version.beta_version
+  - regex: '(Chromium|Chrome)/(\d+)\.(\d+)\.(\d+)'
+
+  # Browser/major_version.minor_version
+  - regex: '(bingbot|Bolt|Jasmine|IceCat|Skyfire|Midori|Maxthon|Lynx|Arora|IBrowse|Dillo|Camino|Shiira|Fennec|Phoenix|Chrome|Flock|Netscape|Lunascape|Epiphany|WebPilot|Opera Mini|Opera|Vodafone|NetFront|Netfront|Konqueror|Googlebot|SeaMonkey|Kazehakase|Vienna|Iceape|Iceweasel|IceWeasel|Iron|K-Meleon|Sleipnir|Galeon|GranParadiso|iCab|NetNewsWire|Space Bison|Stainless|Orca|Dolfin|BOLT|Minimo|Tizen Browser|Polaris|Abrowser|Planetweb|ICE Browser)/(\d+)\.(\d+)'
+
+  # Chrome/Chromium/major_version.minor_version
+  - regex: '(Chromium|Chrome)/(\d+)\.(\d+)'
+
+  # Browser major_version.minor_version.beta_version (space instead of slash)
+  - regex: '(iRider|Crazy Browser|SkipStone|iCab|Lunascape|Sleipnir|Maemo Browser) (\d+)\.(\d+)\.(\d+)'
+  # Browser major_version.minor_version (space instead of slash)
+  - regex: '(iCab|Lunascape|Opera|Android|Jasmine|Polaris) (\d+)\.(\d+)\.?(\d+)?'
+  
+  # Kindle WebKit
+  - regex: '(Kindle)/(\d+)\.(\d+)'
+  
+  # weird android UAs
+  - regex: '(Android) Donut'
+    v1_replacement: '1'
+    v2_replacement: '2'
+
+  - regex: '(Android) Eclair'
+    v1_replacement: '2'
+    v2_replacement: '1'
+
+  - regex: '(Android) Froyo'
+    v1_replacement: '2'
+    v2_replacement: '2'
+
+  - regex: '(Android) Gingerbread'
+    v1_replacement: '2'
+    v2_replacement: '3'
+
+  - regex: '(Android) Honeycomb'
+    v1_replacement: '3'
+
+  # IE Mobile
+  - regex: '(IEMobile)[ /](\d+)\.(\d+)'
+    family_replacement: 'IE Mobile'
+  # desktop mode
+  # http://www.anandtech.com/show/3982/windows-phone-7-review
+  - regex: '(MSIE) (\d+)\.(\d+).*XBLWP7'
+    family_replacement: 'IE Large Screen'
+
+  #### END MAIN CASES ####
+
+  #### SPECIAL CASES ####
+  - regex: '(Obigo)InternetBrowser'
+  - regex: '(Obigo)\-Browser'
+  - regex: '(Obigo|OBIGO)[^\d]*(\d+)(?:.(\d+))?'
+    family_replacement: 'Obigo'
+
+  - regex: '(MAXTHON|Maxthon) (\d+)\.(\d+)'
+    family_replacement: 'Maxthon'
+  - regex: '(Maxthon|MyIE2|Uzbl|Shiira)'
+    v1_replacement: '0'
+
+  - regex: 'PLAYSTATION 3.+WebKit'
+    family_replacement: 'NetFront NX'
+  - regex: 'PLAYSTATION 3'
+    family_replacement: 'NetFront'
+  - regex: '(PlayStation Portable)'
+    family_replacement: 'NetFront'
+  - regex: '(PlayStation Vita)'
+    family_replacement: 'NetFront NX'
+  
+  - regex: 'AppleWebKit.+ (NX)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'NetFront NX'
+  - regex: '(Nintendo 3DS)'
+    family_replacement: 'NetFront NX'
+
+  - regex: '(BrowseX) \((\d+)\.(\d+)\.(\d+)'
+
+  - regex: '(NCSA_Mosaic)/(\d+)\.(\d+)'
+    family_replacement: 'NCSA Mosaic'
+
+  # Polaris/d.d is above
+  - regex: '(POLARIS)/(\d+)\.(\d+)'
+    family_replacement: 'Polaris'
+  - regex: '(Embider)/(\d+)\.(\d+)'
+    family_replacement: 'Polaris'
+
+  - regex: '(BonEcho)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Bon Echo'
+
+  - regex: 'M?QQBrowser'
+    family_replacement: 'QQ Browser'
+
+  - regex: '(iPod).+Version/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Mobile Safari'
+  - regex: '(iPod).*Version/(\d+)\.(\d+)'
+    family_replacement: 'Mobile Safari'
+  - regex: '(iPhone).*Version/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Mobile Safari'
+  - regex: '(iPhone).*Version/(\d+)\.(\d+)'
+    family_replacement: 'Mobile Safari'
+  - regex: '(iPad).*Version/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Mobile Safari'
+  - regex: '(iPad).*Version/(\d+)\.(\d+)'
+    family_replacement: 'Mobile Safari'
+  - regex: '(iPod|iPhone|iPad);.*CPU.*OS (\d+)(?:_\d+)?_(\d+).*Mobile'
+    family_replacement: 'Mobile Safari'
+  - regex: '(iPod|iPhone|iPad)'
+    family_replacement: 'Mobile Safari'
+
+  - regex: '(AvantGo) (\d+).(\d+)'
+  
+  - regex: '(OneBrowser)/(\d+).(\d+)'
+    family_replacement: 'ONE Browser'
+
+  - regex: '(Avant)'
+    v1_replacement: '1'
+
+  # This is the Tesla Model S (see similar entry in device parsers)
+  - regex: '(QtCarBrowser)'
+    v1_replacement: '1'
+
+  - regex: '(iBrowser/Mini)(\d+).(\d+)'
+    family_replacement: 'iBrowser Mini'
+  # nokia browsers
+  # based on: http://www.developer.nokia.com/Community/Wiki/User-Agent_headers_for_Nokia_devices
+  - regex: '^(Nokia)'
+    family_replacement: 'Nokia Services (WAP) Browser'
+  - regex: '(NokiaBrowser)/(\d+)\.(\d+).(\d+)\.(\d+)'
+    family_replacement: 'Nokia Browser'
+  - regex: '(NokiaBrowser)/(\d+)\.(\d+).(\d+)'
+    family_replacement: 'Nokia Browser'
+  - regex: '(NokiaBrowser)/(\d+)\.(\d+)'
+    family_replacement: 'Nokia Browser'
+  - regex: '(BrowserNG)/(\d+)\.(\d+).(\d+)'
+    family_replacement: 'Nokia Browser'
+  - regex: '(Series60)/5\.0'
+    family_replacement: 'Nokia Browser'
+    v1_replacement: '7'
+    v2_replacement: '0'
+  - regex: '(Series60)/(\d+)\.(\d+)'
+    family_replacement: 'Nokia OSS Browser'
+  - regex: '(S40OviBrowser)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Ovi Browser'
+  - regex: '(Nokia)[EN]?(\d+)'
+
+  # BlackBerry devices
+  - regex: '(BB10);'
+    family_replacement: 'BlackBerry WebKit'
+  - regex: '(PlayBook).+RIM Tablet OS (\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'BlackBerry WebKit'
+  - regex: '(Black[bB]erry).+Version/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'BlackBerry WebKit'
+  - regex: '(Black[bB]erry)\s?(\d+)'
+    family_replacement: 'BlackBerry'
+
+  - regex: '(OmniWeb)/v(\d+)\.(\d+)'
+
+  - regex: '(Blazer)/(\d+)\.(\d+)'
+    family_replacement: 'Palm Blazer'
+
+  - regex: '(Pre)/(\d+)\.(\d+)'
+    family_replacement: 'Palm Pre'
+
+  # fork of Links
+  - regex: '(ELinks)/(\d+)\.(\d+)'
+  - regex: '(ELinks) \((\d+)\.(\d+)'
+  - regex: '(Links) \((\d+)\.(\d+)'
+
+  - regex: '(QtWeb) Internet Browser/(\d+)\.(\d+)'
+
+  #- regex: '\(iPad;.+(Version)/(\d+)\.(\d+)(?:\.(\d+))?.*Safari/'
+  #  family_replacement: 'iPad'
+
+  # Amazon Silk, should go before Safari
+  - regex: '(Silk)/(\d+)\.(\d+)(?:\.([0-9\-]+))?'
+    family_replacement: 'Amazon Silk'
+
+  # Phantomjs, should go before Safari
+  - regex: '(PhantomJS)/(\d+)\.(\d+)\.(\d+)'
+
+  # WebKit Nightly
+  - regex: '(AppleWebKit)/(\d+)\.?(\d+)?\+ .* Safari'
+    family_replacement: 'WebKit Nightly'
+
+  # Safari
+  - regex: '(Version)/(\d+)\.(\d+)(?:\.(\d+))?.*Safari/'
+    family_replacement: 'Safari'
+  # Safari didn't provide "Version/d.d.d" prior to 3.0
+  - regex: '(Safari)/\d+'
+
+  - regex: '(OLPC)/Update(\d+)\.(\d+)'
+
+  - regex: '(OLPC)/Update()\.(\d+)'
+    v1_replacement: '0'
+
+  - regex: '(SEMC\-Browser)/(\d+)\.(\d+)'
+
+  - regex: '(Teleca)'
+    family_replacement: 'Teleca Browser'
+    
+  - regex: '(Phantom)/V(\d+)\.(\d+)'
+    family_replacement: 'Phantom Browser'
+
+  - regex: 'Trident(.*)rv.(\d+)\.(\d+)'
+    family_replacement: 'IE'
+
+ # Apple Mail
+
+  # apple mail - not directly detectable, have it after Safari stuff
+  - regex: '(AppleWebKit)/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'AppleMail'
+
+  # AFTER THE EDGE CASES ABOVE!
+  # AFTER IE11
+  # BEFORE all other IE
+  - regex: '(Firefox)/(\d+)\.(\d+)\.(\d+)'
+  - regex: '(Firefox)/(\d+)\.(\d+)(pre|[ab]\d+[a-z]*)?'
+
+  - regex: '([MS]?IE) (\d+)\.(\d+)'
+    family_replacement: 'IE'
+
+  - regex: '(python-requests)/(\d+)\.(\d+)'
+    family_replacement: 'Python Requests'
+
+os_parsers:
+  ##########
+  # HbbTV vendors
+  ##########
+
+  # starts with the easy one : Panasonic seems consistent across years, hope it will continue
+  #HbbTV/1.1.1 (;Panasonic;VIERA 2011;f.532;0071-0802 2000-0000;)
+  #HbbTV/1.1.1 (;Panasonic;VIERA 2012;1.261;0071-3103 2000-0000;)
+  #HbbTV/1.2.1 (;Panasonic;VIERA 2013;3.672;4101-0003 0002-0000;)
+  #- regex: 'HbbTV/\d+\.\d+\.\d+ \(;(Panasonic);VIERA ([0-9]{4});'
+
+  # Sony is consistent too but do not place year like the other
+  # Opera/9.80 (Linux armv7l; HbbTV/1.1.1 (; Sony; KDL32W650A; PKG3.211EUA; 2013;); ) Presto/2.12.362 Version/12.11
+  # Opera/9.80 (Linux mips; U;  HbbTV/1.1.1 (; Sony; KDL40HX751; PKG1.902EUA; 2012;);; en) Presto/2.10.250 Version/11.60
+  # Opera/9.80 (Linux mips; U;  HbbTV/1.1.1 (; Sony; KDL22EX320; PKG4.017EUA; 2011;);; en) Presto/2.7.61 Version/11.00
+  #- regex: 'HbbTV/\d+\.\d+\.\d+ \(; (Sony);.*;.*; ([0-9]{4});\)'
+
+
+  # LG is consistent too, but we need to add manually the year model
+  #Mozilla/5.0 (Unknown; Linux armv7l) AppleWebKit/537.1+ (KHTML, like Gecko) Safari/537.1+ HbbTV/1.1.1 ( ;LGE ;NetCast 4.0 ;03.20.30 ;1.0M ;)
+  #Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ HbbTV/1.1.1 ( ;LGE ;NetCast 3.0 ;1.0 ;1.0M ;)
+  - regex: 'HbbTV/\d+\.\d+\.\d+ \( ;(LG)E ;NetCast 4.0'
+    os_v1_replacement: '2013'
+  - regex: 'HbbTV/\d+\.\d+\.\d+ \( ;(LG)E ;NetCast 3.0'
+    os_v1_replacement: '2012'
+
+  # Samsung is on its way of normalizing their user-agent
+  # HbbTV/1.1.1 (;Samsung;SmartTV2013;T-FXPDEUC-1102.2;;) WebKit
+  # HbbTV/1.1.1 (;Samsung;SmartTV2013;T-MST12DEUC-1102.1;;) WebKit
+  # HbbTV/1.1.1 (;Samsung;SmartTV2012;;;) WebKit
+  # HbbTV/1.1.1 (;;;;;) Maple_2011
+  - regex: 'HbbTV/1.1.1 \(;;;;;\) Maple_2011'
+    os_replacement: 'Samsung'
+    os_v1_replacement: '2011'
+  # manage the two models of 2013
+  - regex: 'HbbTV/\d+\.\d+\.\d+ \(;(Samsung);SmartTV([0-9]{4});.*FXPDEUC'
+    os_v2_replacement: 'UE40F7000'
+  - regex: 'HbbTV/\d+\.\d+\.\d+ \(;(Samsung);SmartTV([0-9]{4});.*MST12DEUC'
+    os_v2_replacement: 'UE32F4500'
+  # generic Samsung (works starting in 2012)
+  #- regex: 'HbbTV/\d+\.\d+\.\d+ \(;(Samsung);SmartTV([0-9]{4});'
+
+  # Philips : not found any other way than a manual mapping
+  # Opera/9.80 (Linux mips; U; HbbTV/1.1.1 (; Philips; ; ; ; ) CE-HTML/1.0 NETTV/4.1.3 PHILIPSTV/1.1.1; en) Presto/2.10.250 Version/11.60
+  # Opera/9.80 (Linux mips ; U; HbbTV/1.1.1 (; Philips; ; ; ; ) CE-HTML/1.0 NETTV/3.2.1; en) Presto/2.6.33 Version/10.70
+  - regex: 'HbbTV/1.1.1 \(; (Philips);.*NETTV/4'
+    os_v1_replacement: '2013'
+  - regex: 'HbbTV/1.1.1 \(; (Philips);.*NETTV/3'
+    os_v1_replacement: '2012'
+  - regex: 'HbbTV/1.1.1 \(; (Philips);.*NETTV/2'
+    os_v1_replacement: '2011'
+
+  # the HbbTV emulator developers use HbbTV/1.1.1 (;;;;;) firetv-firefox-plugin 1.1.20
+  - regex: 'HbbTV/\d+\.\d+\.\d+.*(firetv)-firefox-plugin (\d+).(\d+).(\d+)'
+    os_replacement: 'FireHbbTV'
+
+  # generic HbbTV, hoping to catch manufacturer name (always after 2nd comma) and the first string that looks like a 2011-2019 year
+  - regex: 'HbbTV/\d+\.\d+\.\d+ \(.*; ?([a-zA-Z]+) ?;.*(201[1-9]).*\)'
+
+  ##########
+  # Android
+  # can actually detect rooted android os. do we care?
+  ##########
+  - regex: '(Android) (\d+)\.(\d+)(?:[.\-]([a-z0-9]+))?'
+  - regex: '(Android)\-(\d+)\.(\d+)(?:[.\-]([a-z0-9]+))?'
+
+  - regex: '(Android) Donut'
+    os_v1_replacement: '1'
+    os_v2_replacement: '2'
+
+  - regex: '(Android) Eclair'
+    os_v1_replacement: '2'
+    os_v2_replacement: '1'
+
+  - regex: '(Android) Froyo'
+    os_v1_replacement: '2'
+    os_v2_replacement: '2'
+
+  - regex: '(Android) Gingerbread'
+    os_v1_replacement: '2'
+    os_v2_replacement: '3'
+
+  - regex: '(Android) Honeycomb'
+    os_v1_replacement: '3'
+
+  ##########
+  # Kindle Android
+  ##########
+  - regex: '(Silk-Accelerated=[a-z]{4,5})'
+    os_replacement: 'Android'
+
+  ##########
+  # Windows
+  # http://en.wikipedia.org/wiki/Windows_NT#Releases
+  # possibility of false positive when different marketing names share same NT kernel
+  # e.g. windows server 2003 and windows xp
+  # lots of ua strings have Windows NT 4.1 !?!?!?!? !?!? !? !????!?! !!! ??? !?!?! ?
+  # (very) roughly ordered in terms of frequency of occurence of regex (win xp currently most frequent, etc)
+  ##########
+
+  - regex: '(Windows (?:NT 5\.2|NT 5\.1))'
+    os_replacement: 'Windows XP'
+
+  # ie mobile des ktop mode
+  # spoofs nt 6.1. must come before windows 7
+  - regex: '(XBLWP7)'
+    os_replacement: 'Windows Phone'
+
+  - regex: '(Windows NT 6\.1)'
+    os_replacement: 'Windows 7'
+
+  - regex: '(Windows NT 6\.0)'
+    os_replacement: 'Windows Vista'
+
+  - regex: '(Win 9x 4\.90)'
+    os_replacement: 'Windows Me'
+
+  - regex: '(Windows 98|Windows XP|Windows ME|Windows 95|Windows CE|Windows 7|Windows NT 4\.0|Windows Vista|Windows 2000|Windows 3.1)'
+
+  - regex: '(Windows NT 6\.2; ARM;)'
+    os_replacement: 'Windows RT'
+
+  # is this a spoof or is nt 6.2 out and about in some capacity?
+  - regex: '(Windows NT 6\.2)'
+    os_replacement: 'Windows 8'
+
+  - regex: '(Windows NT 5\.0)'
+    os_replacement: 'Windows 2000'
+
+  - regex: '(Windows Phone) (\d+)\.(\d+)'
+  - regex: '(Windows Phone) OS (\d+)\.(\d+)'
+  - regex: '(Windows ?Mobile)'
+    os_replacement: 'Windows Mobile'
+
+  - regex: '(WinNT4.0)'
+    os_replacement: 'Windows NT 4.0'
+
+  - regex: '(Win98)'
+    os_replacement: 'Windows 98'
+
+  ##########
+  # Tizen OS from Samsung
+  # spoofs Android so pushing it above
+  ##########
+  - regex: '(Tizen)/(\d+)\.(\d+)'
+
+  ##########
+  # Mac OS
+  # http://en.wikipedia.org/wiki/Mac_OS_X#Versions
+  ##########
+  - regex: '(Mac OS X) (\d+)[_.](\d+)(?:[_.](\d+))?'
+  
+  # IE on Mac doesn't specify version number
+  - regex: 'Mac_PowerPC'
+    os_replacement: 'Mac OS'
+
+  # builds before tiger don't seem to specify version?
+
+  # ios devices spoof (mac os x), so including intel/ppc prefixes
+  - regex: '(?:PPC|Intel) (Mac OS X)'
+
+  ##########
+  # iOS
+  # http://en.wikipedia.org/wiki/IOS_version_history
+  ##########
+  - regex: '(CPU OS|iPhone OS) (\d+)_(\d+)(?:_(\d+))?'
+    os_replacement: 'iOS'
+
+  # remaining cases are mostly only opera uas, so catch opera as to not catch iphone spoofs
+  - regex: '(iPhone|iPad|iPod); Opera'
+    os_replacement: 'iOS'
+
+  # few more stragglers
+  - regex: '(iPhone|iPad|iPod).*Mac OS X.*Version/(\d+)\.(\d+)'
+    os_replacement: 'iOS'
+
+  - regex: '(AppleTV)/(\d+)\.(\d+)'
+    os_replacement: 'ATV OS X'
+
+  ##########
+  # Chrome OS
+  # if version 0.0.0, probably this stuff:
+  # http://code.google.com/p/chromium-os/issues/detail?id=11573
+  # http://code.google.com/p/chromium-os/issues/detail?id=13790
+  ##########
+  - regex: '(CrOS) [a-z0-9_]+ (\d+)\.(\d+)(?:\.(\d+))?'
+    os_replacement: 'Chrome OS'
+
+  ##########
+  # Linux distros
+  ##########
+  - regex: '([Dd]ebian)'
+    os_replacement: 'Debian'
+  - regex: '(Linux Mint)(?:/(\d+))?'
+  - regex: '(Mandriva)(?: Linux)?/(?:[\d.-]+m[a-z]{2}(\d+).(\d))?'
+
+  ##########
+  # Symbian + Symbian OS
+  # http://en.wikipedia.org/wiki/History_of_Symbian
+  ##########
+  - regex: '(Symbian[Oo][Ss])/(\d+)\.(\d+)'
+    os_replacement: 'Symbian OS'
+  - regex: '(Symbian/3).+NokiaBrowser/7\.3'
+    os_replacement: 'Symbian^3 Anna'
+  - regex: '(Symbian/3).+NokiaBrowser/7\.4'
+    os_replacement: 'Symbian^3 Belle'
+  - regex: '(Symbian/3)'
+    os_replacement: 'Symbian^3'
+  - regex: '(Series 60|SymbOS|S60)'
+    os_replacement: 'Symbian OS'
+  - regex: '(MeeGo)'
+  - regex: 'Symbian [Oo][Ss]'
+    os_replacement: 'Symbian OS'
+  - regex: 'Series40;'
+    os_replacement: 'Nokia Series 40'
+
+  ##########
+  # BlackBerry devices
+  ##########
+  - regex: '(BB10);.+Version/(\d+)\.(\d+)\.(\d+)'
+    os_replacement: 'BlackBerry OS'
+  - regex: '(Black[Bb]erry)[0-9a-z]+/(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?'
+    os_replacement: 'BlackBerry OS'
+  - regex: '(Black[Bb]erry).+Version/(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?'
+    os_replacement: 'BlackBerry OS'
+  - regex: '(RIM Tablet OS) (\d+)\.(\d+)\.(\d+)'
+    os_replacement: 'BlackBerry Tablet OS'
+  - regex: '(Play[Bb]ook)'
+    os_replacement: 'BlackBerry Tablet OS'
+  - regex: '(Black[Bb]erry)'
+    os_replacement: 'BlackBerry OS'
+
+  ##########
+  # Firefox OS
+  ##########
+  - regex: '\(Mobile;.+Firefox/\d+\.\d+'
+    os_replacement: 'Firefox OS'
+
+  ##########
+  # BREW
+  # yes, Brew is lower-cased for Brew MP
+  ##########
+  - regex: '(BREW)[ /](\d+)\.(\d+)\.(\d+)'
+  - regex: '(BREW);'
+  - regex: '(Brew MP|BMP)[ /](\d+)\.(\d+)\.(\d+)'
+    os_replacement: 'Brew MP'
+  - regex: 'BMP;'
+    os_replacement: 'Brew MP'
+
+  ##########
+  # Google TV
+  ##########
+  - regex: '(GoogleTV) (\d+)\.(\d+)\.(\d+)'
+  # Old style
+  - regex: '(GoogleTV)/[\da-z]+'
+
+  - regex: '(WebTV)/(\d+).(\d+)'
+  
+  ##########
+  # Misc mobile
+  ##########
+  - regex: '(hpw|web)OS/(\d+)\.(\d+)(?:\.(\d+))?'
+    os_replacement: 'webOS'
+  - regex: '(VRE);'
+
+  ##########
+  # Generic patterns
+  # since the majority of os cases are very specific, these go last
+  ##########
+  # first.second.third.fourth bits
+  - regex: '(Fedora|Red Hat|PCLinuxOS)/(\d+)\.(\d+)\.(\d+)\.(\d+)'
+
+  # first.second.third bits
+  - regex: '(Red Hat|Puppy|PCLinuxOS)/(\d+)\.(\d+)\.(\d+)'
+
+  # first.second bits
+  - regex: '(Ubuntu|Kindle|Bada|Lubuntu|BackTrack|Red Hat|Slackware)/(\d+)\.(\d+)'
+
+  # just os
+  - regex: '(Windows|OpenBSD|FreeBSD|NetBSD|Android|WeTab)'
+  - regex: '(Ubuntu|Kubuntu|Arch Linux|CentOS|Slackware|Gentoo|openSUSE|SUSE|Red Hat|Fedora|PCLinuxOS|Gentoo|Mageia)'
+  - regex: '(Linux)/(\d+)\.(\d+)'
+  - regex: '(Linux|BSD)'
+  - regex: 'SunOS'
+    os_replacement: 'Solaris'
+
+device_parsers:
+  ##########
+  # incomplete!
+  # multiple replacement placeholds i.e. ($1) ($2) help solve problem of single device with multiple representations in ua
+  # e.g. HTC Dream S should parse to the same device as HTC_DreamS
+  ##########
+
+  ##########
+  # incomplete!
+  # HTC
+  # http://en.wikipedia.org/wiki/List_of_HTC_phones
+  # this is quickly getting unwieldy
+  ##########
+  # example: Mozilla/5.0 (Linux; U; Android 2.3.2; fr-fr; HTC HD2 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+  - regex: 'HTC ([A-Z][a-z0-9]+) Build'
+    device_replacement: 'HTC $1'
+  # example: Mozilla/5.0 (Linux; U; Android 2.1; es-es; HTC Legend 1.23.161.1 Build/ERD79) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17,gzip
+  - regex: 'HTC ([A-Z][a-z0-9 ]+) \d+\.\d+\.\d+\.\d+'
+    device_replacement: 'HTC $1'
+  # example: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; HTC_Touch_Diamond2_T5353; Windows Phone 6.5.3.5)
+  - regex: 'HTC_Touch_([A-Za-z0-9]+)'
+    device_replacement: 'HTC Touch ($1)'
+  # should come after HTC_Touch
+  - regex: 'USCCHTC(\d+)'
+    device_replacement: 'HTC $1 (US Cellular)'
+  - regex: 'Sprint APA(9292)'
+    device_replacement: 'HTC $1 (Sprint)'
+  - regex: 'HTC ([A-Za-z0-9]+ [A-Z])'
+    device_replacement: 'HTC $1'
+  - regex: 'HTC[-_/\s]([A-Za-z0-9]+)'
+    device_replacement: 'HTC $1'
+  - regex: '(ADR[A-Za-z0-9]+)'
+    device_replacement: 'HTC $1'
+  - regex: '(HTC)'
+
+  # Tesla Model S
+  - regex: '(QtCarBrowser)'
+    device_replacement: 'Tesla Model S'
+
+  # Samsung
+  - regex: '(SamsungSGHi560)'
+    device_replacement: 'Samsung SGHi560'
+
+  #########
+  # Ericsson - must come before nokia since they also use symbian
+  #########
+  - regex: 'SonyEricsson([A-Za-z0-9]+)/'
+    device_replacement: 'Ericsson $1'
+
+  ##########
+  # PlayStation
+  # The Vita spoofs the Kindle
+  ##########
+  - regex: 'PLAYSTATION 3'
+    device_replacement: 'PlayStation 3'
+  - regex: '(PlayStation Portable)'
+  - regex: '(PlayStation Vita)'
+
+  ##########
+  # incomplete!
+  # Kindle
+  # http://amazonsilk.wordpress.com/useful-bits/silk-user-agent/
+  ##########
+  - regex: '(KFOT Build)'
+    device_replacement: 'Kindle Fire'
+  - regex: '(KFTT Build)'
+    device_replacement: 'Kindle Fire HD'
+  - regex: '(KFJWI Build)'
+    device_replacement: 'Kindle Fire HD 8.9" WiFi'
+  - regex: '(KFJWA Build)'
+    device_replacement: 'Kindle Fire HD 8.9" 4G'
+  - regex: '(KFSOWI Build)'
+    device_replacement: 'Kindle Fire HD 7" WiFi'
+  - regex: '(KFTHWI Build)'
+    device_replacement: 'Kindle Fire HDX 7" WiFi'
+  - regex: '(KFTHWA Build)'
+    device_replacement: 'Kindle Fire HDX 7" 4G'
+  - regex: '(KFAPWI Build)'
+    device_replacement: 'Kindle Fire HDX 8.9" WiFi'
+  - regex: '(KFAPWA Build)'
+    device_replacement: 'Kindle Fire HDX 8.9" 4G'
+  - regex: '(Kindle Fire)'
+  - regex: '(Kindle)'
+  - regex: '(Silk)/(\d+)\.(\d+)(?:\.([0-9\-]+))?'
+    device_replacement: 'Kindle Fire'
+      
+  #########
+  # Android General Device Matching (far from perfect)
+  #########
+  - regex: 'Android[\- ][\d]+\.[\d]+; [A-Za-z]{2}\-[A-Za-z]{0,2}; WOWMobile (.+) Build'
+  - regex: 'Android[\- ][\d]+\.[\d]+\-update1; [A-Za-z]{2}\-[A-Za-z]{0,2}; (.+) Build'
+  - regex: 'Android[\- ][\d]+\.[\d]+\.[\d]+; [A-Za-z]{2}\-[A-Za-z]{0,2}; (.+) Build'
+  - regex: 'Android[\- ][\d]+\.[\d]+\.[\d]+;[A-Za-z]{2}\-[A-Za-z]{0,2};(.+) Build'
+  - regex: 'Android[\- ][\d]+\.[\d]+; [A-Za-z]{2}\-[A-Za-z]{0,2}; (.+) Build'
+  - regex: 'Android[\- ][\d]+\.[\d]+\.[\d]+; (.+) Build'
+  - regex: 'Android[\- ][\d]+\.[\d]+; (.+) Build'
+
+  ##########
+  # NOKIA
+  # nokia NokiaN8-00 comes before iphone. sometimes spoofs iphone
+  ##########
+  - regex: 'NokiaN([0-9]+)'
+    device_replacement: 'Nokia N$1'
+  - regex: 'NOKIA([A-Za-z0-9\v-]+)'
+    device_replacement: 'Nokia $1'
+  - regex: 'Nokia([A-Za-z0-9\v-]+)'
+    device_replacement: 'Nokia $1'
+  - regex: 'NOKIA ([A-Za-z0-9\-]+)'
+    device_replacement: 'Nokia $1'
+  - regex: 'Nokia ([A-Za-z0-9\-]+)'
+    device_replacement: 'Nokia $1'
+  - regex: 'Lumia ([A-Za-z0-9\-]+)'
+    device_replacement: 'Lumia $1'
+  - regex: 'Symbian'
+    device_replacement: 'Nokia'
+
+  ##########
+  # BlackBerry
+  # http://www.useragentstring.com/pages/BlackBerry/
+  ##########
+  - regex: 'BB10; ([A-Za-z0-9\- ]+)\)'
+    device_replacement: 'BlackBerry $1'
+  - regex: '(PlayBook).+RIM Tablet OS'
+    device_replacement: 'BlackBerry Playbook'
+  - regex: 'Black[Bb]erry ([0-9]+);'
+    device_replacement: 'BlackBerry $1'
+  - regex: 'Black[Bb]erry([0-9]+)'
+    device_replacement: 'BlackBerry $1'
+  - regex: 'Black[Bb]erry;'
+    device_replacement: 'BlackBerry'
+
+  ##########
+  # PALM / HP
+  ##########
+  # some palm devices must come before iphone. sometimes spoofs iphone in ua
+  - regex: '(Pre)/(\d+)\.(\d+)'
+    device_replacement: 'Palm Pre'
+  - regex: '(Pixi)/(\d+)\.(\d+)'
+    device_replacement: 'Palm Pixi'
+  - regex: '(Touch[Pp]ad)/(\d+)\.(\d+)'
+    device_replacement: 'HP TouchPad'
+  - regex: 'HPiPAQ([A-Za-z0-9]+)/(\d+).(\d+)'
+    device_replacement: 'HP iPAQ $1'
+  - regex: 'Palm([A-Za-z0-9]+)'
+    device_replacement: 'Palm $1'
+  - regex: 'Treo([A-Za-z0-9]+)'
+    device_replacement: 'Palm Treo $1'
+  - regex: 'webOS.*(P160UNA)/(\d+).(\d+)'
+    device_replacement: 'HP Veer'
+
+  ##########
+  # AppleTV
+  # No built in browser that I can tell
+  # Stack Overflow indicated iTunes-AppleTV/4.1 as a known UA for app available and I'm seeing it in live traffic
+  ##########
+  - regex: '(AppleTV)'
+    device_replacement: 'AppleTV'
+
+  ##########
+  # Catch the google mobile crawler before checking for iPhones.
+  ##########
+
+  - regex: 'AdsBot-Google-Mobile'
+    device_replacement: 'Spider'
+   
+  - regex: 'Googlebot-Mobile/(\d+).(\d+)'
+    device_replacement: 'Spider'
+    
+  ##########
+  # complete but probably catches spoofs
+  # iSTUFF
+  ##########
+  # ipad and ipod must be parsed before iphone
+  # cannot determine specific device type from ua string. (3g, 3gs, 4, etc)
+  - regex: '(iPad) Simulator;'
+  - regex: '(iPad);'
+  - regex: '(iPod) touch;'
+  - regex: '(iPod);'
+  - regex: '(iPhone) Simulator;'
+  - regex: '(iPhone);'
+
+  ##########
+  # Acer
+  ##########
+  - regex: 'acer_([A-Za-z0-9]+)_'
+    device_replacement: 'Acer $1'
+  - regex: 'acer_([A-Za-z0-9]+)_'
+    device_replacement: 'Acer $1'
+
+  ##########   
+  # Alcatel
+  ##########
+  - regex: 'ALCATEL-([A-Za-z0-9]+)'
+    device_replacement: 'Alcatel $1'
+  - regex: 'Alcatel-([A-Za-z0-9]+)'
+    device_replacement: 'Alcatel $1'
+
+  ##########
+  # Amoi
+  ##########
+  - regex: 'Amoi\-([A-Za-z0-9]+)'
+    device_replacement: 'Amoi $1'
+  - regex: 'AMOI\-([A-Za-z0-9]+)'
+    device_replacement: 'Amoi $1'
+
+  ##########
+  # Amoi
+  ##########
+  - regex: 'Asus\-([A-Za-z0-9]+)'
+    device_replacement: 'Asus $1'
+  - regex: 'ASUS\-([A-Za-z0-9]+)'
+    device_replacement: 'Asus $1'
+
+  ##########
+  # Bird
+  ##########
+  - regex: 'BIRD\-([A-Za-z0-9]+)'
+    device_replacement: 'Bird $1'
+  - regex: 'BIRD\.([A-Za-z0-9]+)'
+    device_replacement: 'Bird $1'
+  - regex: 'BIRD ([A-Za-z0-9]+)'
+    device_replacement: 'Bird $1'
+
+  ##########
+  # Dell
+  ##########
+  - regex: 'Dell ([A-Za-z0-9]+)'
+    device_replacement: 'Dell $1'
+
+  ##########
+  # DoCoMo
+  ##########
+  - regex: 'DoCoMo/2\.0 ([A-Za-z0-9]+)'
+    device_replacement: 'DoCoMo $1'
+  - regex: '([A-Za-z0-9]+)_W\;FOMA'
+    device_replacement: 'DoCoMo $1'
+  - regex: '([A-Za-z0-9]+)\;FOMA'
+    device_replacement: 'DoCoMo $1'
+
+  ##########
+  # Huawei
+  ##########
+  - regex: 'Huawei([A-Za-z0-9]+)'
+    device_replacement: 'Huawei $1'
+  - regex: 'HUAWEI-([A-Za-z0-9]+)'
+    device_replacement: 'Huawei $1'
+  - regex: 'vodafone([A-Za-z0-9]+)'
+    device_replacement: 'Huawei Vodafone $1'
+
+  ##########
+  # i-mate
+  ##########
+  - regex: 'i\-mate ([A-Za-z0-9]+)'
+    device_replacement: 'i-mate $1'
+
+  ##########
+  # kyocera
+  ##########
+  - regex: 'Kyocera\-([A-Za-z0-9]+)'
+    device_replacement: 'Kyocera $1'
+  - regex: 'KWC\-([A-Za-z0-9]+)'
+    device_replacement: 'Kyocera $1'
+
+  ##########
+  # lenovo
+  ##########
+  - regex: 'Lenovo\-([A-Za-z0-9]+)'
+    device_replacement: 'Lenovo $1'
+  - regex: 'Lenovo_([A-Za-z0-9]+)'
+    device_replacement: 'Lenovo $1'
+
+  ##########
+  # HbbTV (European and Australian standard)
+  # written before the LG regexes, as LG is making HbbTV too
+  ##########
+  - regex: '(HbbTV)/[0-9]+\.[0-9]+\.[0-9]+'
+
+  ##########
+  # lg
+  ##########
+  - regex: 'LG/([A-Za-z0-9]+)'
+    device_replacement: 'LG $1'
+  - regex: 'LG-LG([A-Za-z0-9]+)'
+    device_replacement: 'LG $1'
+  - regex: 'LGE-LG([A-Za-z0-9]+)'
+    device_replacement: 'LG $1'
+  - regex: 'LGE VX([A-Za-z0-9]+)'
+    device_replacement: 'LG $1'
+  - regex: 'LG ([A-Za-z0-9]+)'
+    device_replacement: 'LG $1'
+  - regex: 'LGE LG\-AX([A-Za-z0-9]+)'
+    device_replacement: 'LG $1'
+  - regex: 'LG\-([A-Za-z0-9]+)'
+    device_replacement: 'LG $1'
+  - regex: 'LGE\-([A-Za-z0-9]+)'
+    device_replacement: 'LG $1'
+  - regex: 'LG([A-Za-z0-9]+)'
+    device_replacement: 'LG $1'
+
+  ##########
+  # kin
+  ##########
+  - regex: '(KIN)\.One (\d+)\.(\d+)'
+    device_replacement: 'Microsoft $1'
+  - regex: '(KIN)\.Two (\d+)\.(\d+)'
+    device_replacement: 'Microsoft $1'
+
+  ##########
+  # motorola
+  ##########
+  - regex: '(Motorola)\-([A-Za-z0-9]+)'
+  - regex: 'MOTO\-([A-Za-z0-9]+)'
+    device_replacement: 'Motorola $1'
+  - regex: 'MOT\-([A-Za-z0-9]+)'
+    device_replacement: 'Motorola $1'
+    
+  ##########
+  # nintendo
+  ##########
+  - regex: '(Nintendo WiiU)'
+    device_replacement: 'Nintendo Wii U'
+  - regex: 'Nintendo (DS|3DS|DSi|Wii);'
+    device_replacement: 'Nintendo $1'
+
+  ##########
+  # pantech
+  ##########
+  - regex: 'Pantech([A-Za-z0-9]+)'
+    device_replacement: 'Pantech $1'
+ 
+  ##########
+  # philips
+  ##########
+  - regex: 'Philips([A-Za-z0-9]+)'
+    device_replacement: 'Philips $1'
+  - regex: 'Philips ([A-Za-z0-9]+)'
+    device_replacement: 'Philips $1'
+
+  ##########
+  # Samsung
+  ##########
+  - regex: 'SAMSUNG-([A-Za-z0-9\-]+)'
+    device_replacement: 'Samsung $1'
+  - regex: 'SAMSUNG\; ([A-Za-z0-9\-]+)'
+    device_replacement: 'Samsung $1'
+
+  ##########
+  # Sega
+  ##########
+  - regex: 'Dreamcast'
+    device_replacement: 'Sega Dreamcast'
+
+  ##########
+  # Softbank
+  ##########
+  - regex: 'Softbank/1\.0/([A-Za-z0-9]+)'
+    device_replacement: 'Softbank $1'
+  - regex: 'Softbank/2\.0/([A-Za-z0-9]+)'
+    device_replacement: 'Softbank $1'
+
+  ##########
+  # WebTV
+  ##########
+  - regex: '(WebTV)/(\d+).(\d+)'
+
+  ##########
+  # Generic Smart Phone
+  ##########
+  - regex: '(hiptop|avantgo|plucker|xiino|blazer|elaine|up.browser|up.link|mmp|smartphone|midp|wap|vodafone|o2|pocket|mobile|pda)'
+    device_replacement: "Generic Smartphone"
+
+  ##########
+  # Generic Feature Phone
+  ##########
+  - regex: '^(1207|3gso|4thp|501i|502i|503i|504i|505i|506i|6310|6590|770s|802s|a wa|acer|acs\-|airn|alav|asus|attw|au\-m|aur |aus |abac|acoo|aiko|alco|alca|amoi|anex|anny|anyw|aptu|arch|argo|bell|bird|bw\-n|bw\-u|beck|benq|bilb|blac|c55/|cdm\-|chtm|capi|comp|cond|craw|dall|dbte|dc\-s|dica|ds\-d|ds12|dait|devi|dmob|doco|dopo|el49|erk0|esl8|ez40|ez60|ez70|ezos|ezze|elai|emul|eric|ezwa|fake|fly\-|fly_|g\-mo|g1 u|g560|gf\-5|grun|gene|go.w|good|grad|hcit|hd\-m|hd\-p|hd\-t|hei\-|hp i|hpip|hs\-c|htc |htc\-|htca|htcg)'
+    device_replacement: 'Generic Feature Phone'
+  - regex: '^(htcp|htcs|htct|htc_|haie|hita|huaw|hutc|i\-20|i\-go|i\-ma|i230|iac|iac\-|iac/|ig01|im1k|inno|iris|jata|java|kddi|kgt|kgt/|kpt |kwc\-|klon|lexi|lg g|lg\-a|lg\-b|lg\-c|lg\-d|lg\-f|lg\-g|lg\-k|lg\-l|lg\-m|lg\-o|lg\-p|lg\-s|lg\-t|lg\-u|lg\-w|lg/k|lg/l|lg/u|lg50|lg54|lge\-|lge/|lynx|leno|m1\-w|m3ga|m50/|maui|mc01|mc21|mcca|medi|meri|mio8|mioa|mo01|mo02|mode|modo|mot |mot\-|mt50|mtp1|mtv |mate|maxo|merc|mits|mobi|motv|mozz|n100|n101|n102|n202|n203|n300|n302|n500|n502|n505|n700|n701|n710|nec\-|nem\-|newg|neon)'
+    device_replacement: 'Generic Feature Phone'
+  - regex: '^(netf|noki|nzph|o2 x|o2\-x|opwv|owg1|opti|oran|ot\-s|p800|pand|pg\-1|pg\-2|pg\-3|pg\-6|pg\-8|pg\-c|pg13|phil|pn\-2|pt\-g|palm|pana|pire|pock|pose|psio|qa\-a|qc\-2|qc\-3|qc\-5|qc\-7|qc07|qc12|qc21|qc32|qc60|qci\-|qwap|qtek|r380|r600|raks|rim9|rove|s55/|sage|sams|sc01|sch\-|scp\-|sdk/|se47|sec\-|sec0|sec1|semc|sgh\-|shar|sie\-|sk\-0|sl45|slid|smb3|smt5|sp01|sph\-|spv |spv\-|sy01|samm|sany|sava|scoo|send|siem|smar|smit|soft|sony|t\-mo|t218|t250|t600|t610|t618|tcl\-|tdg\-|telm|tim\-|ts70|tsm\-|tsm3|tsm5|tx\-9|tagt)'
+    device_replacement: 'Generic Feature Phone'
+  - regex: '^(talk|teli|topl|tosh|up.b|upg1|utst|v400|v750|veri|vk\-v|vk40|vk50|vk52|vk53|vm40|vx98|virg|vite|voda|vulc|w3c |w3c\-|wapj|wapp|wapu|wapm|wig |wapi|wapr|wapv|wapy|wapa|waps|wapt|winc|winw|wonu|x700|xda2|xdag|yas\-|your|zte\-|zeto|aste|audi|avan|blaz|brew|brvw|bumb|ccwa|cell|cldc|cmd\-|dang|eml2|fetc|hipt|http|ibro|idea|ikom|ipaq|jbro|jemu|jigs|keji|kyoc|kyok|libw|m\-cr|midp|mmef|moto|mwbp|mywa|newt|nok6|o2im|pant|pdxg|play|pluc|port|prox|rozo|sama|seri|smal|symb|treo|upsi|vx52|vx53|vx60|vx61|vx70|vx80|vx81|vx83|vx85|wap\-|webc|whit|wmlb|xda\-|xda_)'
+    device_replacement: 'Generic Feature Phone'
+
+  ##########
+  # Spiders (this is hack...)
+  ##########
+  - regex: '(bingbot|bot|borg|google(^tv)|yahoo|slurp|msnbot|msrbot|openbot|archiver|netresearch|lycos|scooter|altavista|teoma|gigabot|baiduspider|blitzbot|oegp|charlotte|furlbot|http%20client|polybot|htdig|ichiro|mogimogi|larbin|pompos|scrubby|searchsight|seekbot|semanticdiscovery|silk|snappy|speedy|spider|voila|vortex|voyager|zao|zeal|fast\-webcrawler|converacrawler|dataparksearch|findlinks|crawler)'
+    device_replacement: 'Spider'
+

--- a/test_resources/test_device_outdated.yaml
+++ b/test_resources/test_device_outdated.yaml
@@ -1,0 +1,328 @@
+test_cases:
+
+  - user_agent_string: 'ALCATEL-OT510A/382 ObigoInternetBrowser/Q05A'
+    family: 'Alcatel OT510A'
+
+  - user_agent_string: 'Alcatel-OH5/1.0 UP.Browser/6.1.0.7.7 (GUI) MMP/1.0'
+    family: 'Alcatel OH5'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; Amaze_4G Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'Amaze_4G'
+
+  - user_agent_string: 'Opera/9.80 (BlackBerry; Opera Mini/7.0.31437/28.3030; U; en) Presto/2.8.119 Version/11.10'
+    family: 'BlackBerry'
+
+  - user_agent_string: 'Mozilla/5.0 (BlackBerry; U; BlackBerry 9320; en-GB) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.1.0.398 Mobile Safari/534.11+'
+    family: 'BlackBerry 9320'
+
+  - user_agent_string: 'Mozilla/5.0 (PlayBook; U; RIM Tablet OS 1.0.0; en-US) AppleWebKit/534.8+ (KHTML, like Gecko) Version/0.0.1 Safari/534.8+'
+    family: 'BlackBerry Playbook'
+
+  - user_agent_string: 'Mozilla/5.0 (BB10; Touch) AppleWebKit/537.3+ (KHTML, like Gecko) Version/10.0.9.388 Mobile Safari/537.3+'
+    family: 'BlackBerry Touch'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 4.2; Galaxy Nexus Build/JOP40C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19'
+    family: 'Galaxy Nexus'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 3.0.1; en-us; GT-P7510 Build/HRI83) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13'
+    family: 'GT-P7510'
+
+  - user_agent_string: 'Mozilla/5.0 (hp-tablet; Linux; hpwOS/3.0.5; U; en-US) AppleWebKit/534.6 (KHTML, like Gecko) wOSBrowser/234.83 Safari/534.6 TouchPad/1.0'
+    family: 'HP TouchPad'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.2.2; en-gb; HTC Desire Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'
+    family: 'HTC Desire'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.3.3; en-fr; HTC/WildfireS/1.33.163.2 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'
+    family: 'HTC WildfireS'
+
+  - user_agent_string: 'QQBrowser (Linux; U; zh-cn; HTC Hero Build/FRF91)'
+    family: 'HTC Hero'
+
+  - user_agent_string: 'Huawei/1.0/0HuaweiG2800/WAP2.0/Obigo-Browser/Q03C MMS/Obigo-MMS/1.2'
+    family: 'Huawei G2800'
+
+  - user_agent_string: 'HUAWEI-M750/001.00 ACS-NetFront/3.2'
+    family: 'Huawei M750'
+
+  - user_agent_string: 'Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10'
+    family: 'iPad'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; U; fr; CPU iPhone OS 4_2_1 like Mac OS X; fr) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148a Safari/6533.18.5'
+    family: 'iPhone'
+
+  - user_agent_string: 'Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_2 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8H7 Safari/6533.18.5'
+    family: 'iPod'
+
+  - user_agent_string: 'Mozilla/5.0 (iPod touch; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/537.40 (KHTML, like Gecko) Version/6.0 Mobile/11A4400f Safari/8536.25'
+    family: 'iPod'
+
+  - user_agent_string: 'Mozilla/4.0 (compatible; Linux 2.6.10) NetFront/3.3 Kindle/1.0 (screen 600x800)'
+    family: 'Kindle'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; Kindle Fire Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'
+    family: 'Kindle Fire'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; en-us; KFTT Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Silk/2.0 Safari/535.19 Silk-Accelerated=false'
+    family: 'Kindle Fire HD'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; KFTT Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30'
+    family: 'Kindle Fire HD'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; en-us; KFTT Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Silk/2.2 Safari/535.19 Silk-Accelerated=true'
+    family: 'Kindle Fire HD'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; en-us; KFSOWI Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.7 Safari/535.19 Silk-Accelerated=true'
+    family: 'Kindle Fire HD 7" WiFi'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; en-us; KFTHWI Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.6 Safari/535.19 Silk-Accelerated=true'
+    family: 'Kindle Fire HDX 7" WiFi'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; en-us; KFTHWA Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.6 Safari/535.19 Silk-Accelerated=true'
+    family: 'Kindle Fire HDX 7" 4G'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; en-us; KFAPWI Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.6 Safari/535.19 Silk-Accelerated=true'
+    family: 'Kindle Fire HDX 8.9" WiFi'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; en-us; KFAPWA Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.6 Safari/535.19 Silk-Accelerated=true'
+    family: 'Kindle Fire HDX 8.9" 4G'
+
+  - user_agent_string: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us; Silk/1.1.0-80) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16 Silk-Accelerated=true'
+    family: 'Kindle Fire'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; en-us; KFOT Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Silk/2.1 Safari/535.19 Silk-Accelerated=true'
+    family: 'Kindle Fire'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; KFOT Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30'
+    family: 'Kindle Fire'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; en-US) AppleWebKit/528.5+ (KHTML, like Gecko, Safari/528.5+) Version/4.0 Kindle/3.0 (screen 600x800; rotate)'
+    family: 'Kindle'
+
+  - user_agent_string: 'NetFront/4.2 (BMP 1.0.4; U; en-us; LG; NetFront/4.2/AMB) Boost LG272 MMP/2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1'
+    family: 'LG 272'
+
+  - user_agent_string: 'Opera/9.80 (BREW; Opera Mini/5.1.191/27.2202; U; en) Presto/2.8.119 240X400 LG VN271'
+    family: 'LG VN271'
+
+  - user_agent_string: 'Mozilla/5.0 (LG-T500 AppleWebkit/531 Browser/Phantom/V2.0 Widget/LGMW/3.0 MMS/LG-MMS-V1.0/1.2 Java/ASVM/1.1 Profile/MIDP-2.1 Configuration/CLDC-1.1)'
+    family: 'LG T500'
+
+  - user_agent_string: 'Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; NOKIA; Lumia 800)'
+    family: 'Lumia 800'
+
+  - user_agent_string: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 920)'
+    family: 'Lumia 920'
+
+  - user_agent_string: 'Bunjalloo/0.7.6(Nintendo DS;U;en)'
+    family: 'Nintendo DS'
+
+  - user_agent_string: 'Opera/9.50 (Nintendo DSi; Opera/507; U; en-US)'
+    family: 'Nintendo DSi'
+
+  - user_agent_string: 'Mozilla/5.0 (Nintendo 3DS; U; ; en) Version/1.7498.US'
+    family: 'Nintendo 3DS'
+
+  - user_agent_string: 'Opera/9.30 (Nintendo Wii; U; ; 3642; en)'
+    family: 'Nintendo Wii'
+
+  - user_agent_string: 'Mozilla/5.0 (Nintendo WiiU) AppleWebKit/534.52 (KHTML, like Gecko) NX/2.1.0.8.21 NintendoBrowser/1.0.0.7494.US'
+    family: 'Nintendo Wii U'
+
+  - user_agent_string: 'Nokia201/2.0 (11.21) Profile/MIDP-2.1 Configuration/CLDC-1.1 Mozilla/5.0 (Java; U; en-us; nokia201) UCBrowser8.3.0.154/70/355/UCWEB Mobile'
+    family: 'Nokia 201'
+
+  - user_agent_string: 'iBrowser/Mini2.8 (Nokia5130c-2/07.97)'
+    family: 'Nokia 5130c-2'
+
+  - user_agent_string: 'Nokia5320di/UCWEB8.0.3.99/28/999'
+    family: 'Nokia 5320di'
+
+  - user_agent_string: 'Mozilla/5.0 (SymbianOS/9.4; U; Series60/5.0 Nokia5800d-1/21.0.025; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/413 (KHTML, like Gecko) Safari/413'
+    family: 'Nokia 5800d-1'
+
+  - user_agent_string: 'NOKIA6120c/UC Browser7.4.0.65/28/352'
+    family: 'Nokia 6120c'
+
+  - user_agent_string: 'Mozilla/5.0 (Symbian/3; Series60/5.3 Nokia701/111.020.0307; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/533.4 (KHTML, like Gecko) NokiaBrowser/7.4.1.14 Mobile Safari/533.4 3gpp-gba'
+    family: 'Nokia 701'
+
+  - user_agent_string: 'OneBrowser/3.0 (NokiaC2-00/03.42)'
+    family: 'Nokia C2-00'
+
+  - user_agent_string: 'Mozilla/5.0 (Series40; NokiaC2-03/07.48; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/2.2.0.0.33'
+    family: 'Nokia C2-03'
+
+  - user_agent_string: 'Mozilla/5.0 (S60V5; U; en-us; NokiaC5-03) AppleWebKit/530.13 (KHTML, like Gecko) UCBrowser/8.7.0.218/50/352/UCWEB Mobile'
+    family: 'Nokia C5-03'
+
+  - user_agent_string: 'Mozilla/5.0 (Series40; NokiaX2-05/08.35; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/2.0.2.68.14'
+    family: 'Nokia X2-05'
+
+  - user_agent_string: 'Mozilla/5.0 (Symbian/3; Series60/5.2 NokiaN8-00/013.016; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/525 (KHTML, like Gecko) Version/3.0 BrowserNG/7.2.8.10 3gpp-gba'
+    family: 'Nokia N8'
+
+  - user_agent_string: 'Mozilla/5.0 (Symbian/3; Series60/5.2 NokiaN8-00/012.002; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/533.4 (KHTML, like Gecko) NokiaBrowser/7.3.0 Mobile Safari/533.4 3gpp-gba'
+    family: 'Nokia N8'
+
+  - user_agent_string: 'Mozilla/5.0 (MeeGo; NokiaN9) AppleWebKit/534.13 (KHTML, like Gecko) NokiaBrowser/8.5.0 Mobile Safari/534.13'
+    family: 'Nokia N9'
+
+  - user_agent_string: 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; XBLWP7; ZuneWP7)'
+    family: 'Other'
+
+  - user_agent_string: 'IUC(U;iOS 5.1.1;Zh-cn;320*480;)/UCWEB7.9.0.94/41/997'
+    family: 'Other'
+
+  - user_agent_string: 'J2ME/UCWEB7.0.3.45/139/7682'
+    family: 'Other'
+
+  - user_agent_string: 'Mozilla/4.0 (BREW 3.1.5; U; en-us; Sanyo; NetFront/3.5.1/AMB) Boost SCP3810'
+    family: 'Other'
+
+  - user_agent_string: 'Mozilla/4.0 (Brew MP 1.0.2; U; en-us; Sanyo; NetFront/3.5.1/AMB) Sprint E4100'
+    family: 'Other'
+
+  - user_agent_string: 'NetFront/3.5.1 (BREW 3.1.5; U; en-us; LG; NetFront/3.5.1/WAP) Sprint LN240 MMP/2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1'
+    family: 'Other'
+
+  - user_agent_string: 'Mozilla/4.0 (compatible; MSIE 5.17; Mac_PowerPC)'
+    family: 'Other'
+
+  - user_agent_string: 'NCSA_Mosaic/2.0 (Windows 3.1)'
+    family: 'Other'
+
+  - user_agent_string: 'Mozilla/5.0 (X11; U; SunOS i86pc; en-US; rv:1.8.0.5) Gecko/20060728 Firefox/1.5.0.5'
+    family: 'Other'
+
+  - user_agent_string: 'Mozilla/5.0 (Windows; U; Windows NT 6.1; zh_CN) AppleWebKit/534.7 (KHTML, like Gecko) Chrome/7.0 baidubrowser/1.x Safari/534.7'
+    family: 'Other'
+
+  - user_agent_string: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; baidubrowser 1.x)'
+    family: 'Other'
+
+  - user_agent_string: 'ICE Browser/5.05 (Java 1.4.0; Windows 2000 5.0 x86)'
+    family: 'Other'
+
+  - user_agent_string: 'MQQBrowser/371 Mozilla/5.0 (iPhone 4S; CPU iPhone OS 6_0_1 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Mobile/10A523 Safari/7534.48.3'
+    family: 'Other'
+
+  - user_agent_string: 'Opera/9.80 (VRE; Opera Mini/4.2/28.2794; U; en) Presto/2.8.119 Version/11.10'
+    family: 'Other'
+
+  - user_agent_string: 'Mozilla/5.0 (Mobile; rv:15.0) Gecko/15.0 Firefox/15.0'
+    family: 'Other'
+
+  - user_agent_string: 'PantechP6010/JNUS11072011 BMP/1.0.2 DeviceId/141020 NetFront/4.1 OMC/1.5.3 Profile/MIDP-2.1 Configuration/CLDC-1.1'
+    family: 'Pantech P6010'
+
+  - user_agent_string: 'PantechP7040/JLUS04042011 Browser/Obigo/Q05A OMC/1.5.3 Profile/MIDP-2.1 Configuration/CLDC-1.1'
+    family: 'Pantech P7040'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; PJ83100/2.20.502.7 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.0'
+    family: 'PJ83100/2.20.502.7'
+
+  - user_agent_string: 'Mozilla/5.0 (PLAYSTATION 3; 3.55)'
+    family: 'PlayStation 3'
+
+  - user_agent_string: 'Mozilla/5.0 (PLAYSTATION 3 4.31) AppleWebKit/531.22.8 (KHTML, like Gecko)'
+    family: 'PlayStation 3'
+
+  - user_agent_string: 'Mozilla/4.0 (PSP (PlayStation Portable); 2.00)'
+    family: 'PlayStation Portable'
+
+  - user_agent_string: 'Mozilla/5.0 (PlayStation Vita 1.81) AppleWebKit/531.22.8 (KHTML, like Gecko) Silk/3.2'
+    family: 'PlayStation Vita'
+
+  - user_agent_string: 'SAMSUNG-C3053/1.0 Openwave/6.2.3 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0'
+    family: 'Samsung C3053'
+
+  - user_agent_string: 'OneBrowser/3.0 (SAMSUNG-GT-S5253/S5253DDKJ2)'
+    family: 'Samsung GT-S5253'
+
+  - user_agent_string: 'Mozilla/3.0 (Planetweb/2.100 JS SSL US; Dreamcast US)'
+    family: 'Sega Dreamcast'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; Android 4.1.1; SPH-L710 Build/JRO03L) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19'
+    family: 'SPH-L710'
+
+  - user_agent_string: 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
+    family: 'Spider'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux;U;Android 2.3.5;en-us;TECNO T3 Build/master) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'
+    family: 'TECNO T3'
+
+  - user_agent_string: 'Mozilla/5.0 (X11i; Linux; C) AppleWebKikt/533.3 (KHTML, like Gecko) QtCarBrowser Safari/533.3'
+    family: 'Tesla Model S'
+
+  - user_agent_string: 'Mozilla/4.0 WebTV/2.6 (compatible; MSIE 4.0)'
+    family: 'WebTV'
+
+  - user_agent_string: 'AdsBot-Google-Mobile (+http://www.google.com/mobile/adsbot.html) Mozilla (iPhone; U; CPU iPhone OS 3 0 like Mac OS X) AppleWebKit (KHTML, like Gecko) Mobile Safari'
+    family: 'Spider'
+
+  - user_agent_string: 'magpie-crawler/1.1 (U; Linux amd64; en-GB; +http://www.brandwatch.net)'
+    family: 'Spider'
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8B117 Safari/6531.22.7 (compatible; Googlebot-Mobile/2.1; +http://www.google.com/bot.html)'
+    family: 'Spider'
+
+  - user_agent_string: 'Mozilla/5.0 (Linux; U; Android 4.1.2; en-; GT-N7000 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
+    family: 'GT-N7000'
+
+  - user_agent_string: 'HbbTV/1.1.1 (;Panasonic;VIERA 2012;1.261;0071-3103 2000-0000;)'
+    family: 'HbbTV'
+
+  - user_agent_string: 'Mozilla/5.0 (Unknown; Linux armv7l) AppleWebKit/537.1+ (KHTML, like Gecko) Safari/537.1+ HbbTV/1.1.1 ( ;LGE ;NetCast 4.0 ;03.20.30 ;1.0M ;)'
+    family: 'HbbTV'
+
+  - user_agent_string: 'Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ HbbTV/1.1.1 ( ;LGE ;NetCast 3.0 ;1.0 ;1.0M ;)'
+    family: 'HbbTV'
+
+  - user_agent_string: 'Opera/9.80 (Linux armv7l; HbbTV/1.1.1 (; Sony; KDL32W650A; PKG3.211EUA; 2013;); ) Presto/2.12.362 Version/12.11'
+    family: 'HbbTV'
+
+  - user_agent_string: 'HbbTV/1.1.1 (;Panasonic;VIERA 2012;1.261;0071-3103 2000-0000;)'
+    family: 'HbbTV'
+
+  - user_agent_string: 'Mozilla/5.0 (Unknown; Linux armv7l) AppleWebKit/537.1+ (KHTML, like Gecko) Safari/537.1+ HbbTV/1.1.1 ( ;LGE ;NetCast 4.0 ;03.20.30 ;1.0M ;)'
+    family: 'HbbTV'
+
+  - user_agent_string: 'Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ HbbTV/1.1.1 ( ;LGE ;NetCast 3.0 ;1.0 ;1.0M ;)'
+    family: 'HbbTV'
+
+  - user_agent_string: 'Opera/9.80 (Linux armv7l; HbbTV/1.1.1 (; Sony; KDL32W650A; PKG3.211EUA; 2013;); ) Presto/2.12.362 Version/12.11'
+    family: 'HbbTV'
+
+# up market model
+  - user_agent_string: 'HbbTV/1.1.1 (;Samsung;SmartTV2013;T-FXPDEUC-1102.2;;) WebKit'
+    family: 'HbbTV'
+
+# mid-range model
+  - user_agent_string: 'HbbTV/1.1.1 (;Samsung;SmartTV2013;T-MST12DEUC-1102.1;;) WebKit'
+    family: 'HbbTV'
+
+  - user_agent_string: 'HbbTV/1.2.1 (;Panasonic;VIERA 2013;3.672;4101-0003 0002-0000;)'
+    family: 'HbbTV'
+
+# no way to differentiate models
+  - user_agent_string: 'HbbTV/1.1.1 (;Samsung;SmartTV2012;;;) WebKit'
+    family: 'HbbTV'
+
+  - user_agent_string: 'HbbTV/1.1.1 (;Panasonic;VIERA 2012;1.261;0071-3103 2000-0000;)'
+    family: 'HbbTV'
+
+  - user_agent_string: 'Opera/9.80 (Linux mips ; U; HbbTV/1.1.1 (; Philips; ; ; ; ) CE-HTML/1.0 NETTV/3.2.1; en) Presto/2.6.33 Version/10.70'
+    family: 'HbbTV'
+
+  - user_agent_string: 'HbbTV/1.1.1 (;;;;;) Maple_2011'
+    family: 'HbbTV'
+
+  - user_agent_string: 'Opera/9.80 (Linux mips; U;  HbbTV/1.1.1 (; Sony; KDL22EX320; PKG4.017EUA; 2011;);; en) Presto/2.7.61 Version/11.00'
+    family: 'HbbTV'
+
+  - user_agent_string: 'HbbTV/1.1.1 (;Panasonic;VIERA 2011;f.532;0071-0802 2000-0000;)'
+    family: 'HbbTV'
+
+  - user_agent_string: 'HbbTV/1.1.1 (;;;;;) firetv-firefox-plugin 1.1.20'
+    family: 'HbbTV'


### PR DESCRIPTION
For device parsing a better segmentation is being introduced for Android and other Devices. 

To add information on "brand" and "model" two new types `brand_replacement` and `model_replacement` have been added to the `device_parser` in the regexes.yaml file. 
In order to keep backward compatibility the `device_replacement` is left untouched for most of the cases.

To facilitate segmentation a multi replacement function for "family", "brand" and "model" is introduced to cope with user-agent-strings which are quite different from each other but specify the same device. 
Now $1 ... $9 can be used to reference up to nine matchers.
**Note:** This breaks compatibility with all parsers which currently lack this feature. This PR incudes updates for JS, Perl and Python parsers.

Further refinement of device.family, brand and model, especially with HTC devices will be subject to an upcoming PR. 
