### PR TITLE
PHP: Converting the errors from UAParse construct into a thrown Exception

### DIFF
--- a/php/uaparser-cli.php
+++ b/php/uaparser-cli.php
@@ -149,7 +149,11 @@ if (php_sapi_name() == 'cli') {
         /* Parse the supplied Apache log file */
         
         // load the parser
-        $parser = new UAParser;
+        try {
+            $parser = new UAParser;
+        } catch (FileNotFound_Exception $e) {
+            exit($e->getMessage());
+        }
         
         // set-up some standard vars
         $i       = 0;
@@ -207,7 +211,11 @@ if (php_sapi_name() == 'cli') {
         /* Parse the supplied UA from the command line and kick it out as JSON */
         
         // load the parser
-        $parser = new UAParser;
+        try {
+            $parser = new UAParser;
+        } catch (FileNotFound_Exception $e) {
+            exit($e->getMessage());
+        }
         
         // parse and encode the results
         if (version_compare(PHP_VERSION, '5.4.0', '>=') && isset($args["p"])) {
@@ -222,7 +230,11 @@ if (php_sapi_name() == 'cli') {
         /* Parse the supplied UA from the command line and kick it out as JSON */
         
         // load the parser
-        $parser = new UAParser;
+        try {
+            $parser = new UAParser;
+        } catch (FileNotFound_Exception $e) {
+            exit($e->getMessage());
+        }
         
         // parse and print the results
         $result = $parser->parse($argv[1]);

--- a/php/uaparser.php
+++ b/php/uaparser.php
@@ -48,31 +48,15 @@ class UAParser {
         } else {
             $title            = 'Error loading ua-parser';
             if ($customRegexesFile !== null) {
-                $message      = 'ua-parser can\'t find the custom regexes file you supplied ('.$customRegexesFile.'). Please make sure you have the correct path.';
-                $instruction1 = '';
-                $instruction2 = '';
+                $message = 'ua-parser can\'t find the custom regexes file you supplied ('.$customRegexesFile.'). Please make sure you have the correct path.';
             } else {
-                $message      = 'Please download the regexes.json file before using uaparser.php. You can type the following at the command line to download the latest version: ';
-                $instruction1 = '%: cd /path/to/UAParser/';
-                $instruction2 = '%: php uaparser-cli.php -g';
+                $message = 'Please download the regexes.json file before using uaparser.php.';
+                if ( php_sapi_name() == 'cli' ) {
+                    $message .= ' (php uaparser-cli.php -g)';
+                }
             }
             
-            if (php_sapi_name() == 'cli') {
-                print "\n".$title."\n";
-                print $message."\n\n";
-                print "    ".$instruction2."\n\n";
-            } else {
-                print '<html><head><title>'.$title.'</title></head><body>';
-                print '<h1>'.$title.'</h1>';
-                print '<p>'.$message.'</p>';
-                print '<blockquote>';
-                print '<code>'.$instruction1.'</code><br>';
-                print '<code>'.$instruction2.'</code>';
-                print '</blockquote>';
-                print '</body></html>';
-            }
-
-            exit;
+            throw new FileNotFound_Exception($message);
         }
     }
     
@@ -301,3 +285,5 @@ class UAParser {
     }
     
 }
+
+class FileNotFound_Exception extends Exception {}


### PR DESCRIPTION
Coming across some errors where we're using UAParser in our projects; when loading it automatically, if regexes.yaml/.json haven't been downloaded the whole project explodes. Being able to catch a thrown Exception would make things much easier for us and also reacts a bit better to any usage (other than just echoing out the issues).
