### PR TITLE
C++ ua-parser implementation

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright 2013 Andrew Punch
+#
+# Licensed under the Apache License, Version 2.0 (the 'License')
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 2.8)
+
+set(CMAKE_CXX_FLAGS "-g")
+ 
+if(COMMAND cmake_policy)
+  cmake_policy(SET CMP0003 NEW)
+endif(COMMAND cmake_policy)
+
+add_library(ua_parser ua_parser.cpp)
+target_link_libraries(ua_parser yaml-cpp boost_regex)
+
+add_executable(ua_parser_cli main.cpp)
+target_link_libraries(ua_parser_cli ua_parser)
+
+add_executable(ua_parser_test ua_parser_test.cpp)
+target_link_libraries(ua_parser_test ua_parser gtest pthread)

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -1,0 +1,42 @@
+/*
+# Copyright 2013 Andrew Punch
+#
+# Licensed under the Apache License, Version 2.0 (the 'License')
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.#include "ua_parser.h"
+*/
+
+#include "ua_parser.h"
+
+int main(int argc, char *argv[]) {
+  std::string user_agent_string("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/30.0.1599.114 Chrome/30.0.1599.114 Safari/537.36");
+  std::string yaml_file("../regexes.yaml");
+
+  if (argc>1 && std::string(argv[1])=="--help") {
+    std::cout << "Usage: ua_parser_cli [user agent string] [regexes.yaml]" << std::endl;
+    return 1;
+  } else if (argc>1)
+    user_agent_string = argv[1];
+
+  if (argc>2)
+    yaml_file = argv[2];
+
+  ua_parser::Parser uap(yaml_file);
+
+  ua_parser::UserAgent ua = uap.Parse(user_agent_string);
+
+  if (ua.browser.family.empty())
+    return 2;
+
+  std::cout << ua.browser.family << std::endl;
+  std::cout << ua.os.os << std::endl;
+  std::cout << ua.device << std::endl;
+}

--- a/cpp/ua_parser.cpp
+++ b/cpp/ua_parser.cpp
@@ -1,0 +1,230 @@
+/*
+# Copyright 2013 Andrew Punch
+#
+# Licensed under the Apache License, Version 2.0 (the 'License')
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/
+
+
+#include <fstream>
+#include <boost/algorithm/string/replace.hpp>
+#include <yaml-cpp/yaml.h>
+#include "ua_parser.h"
+
+
+
+namespace ua_parser {
+BrowserParser::BrowserParser(const YAML::Node &yaml_attributes) {
+  yaml_attributes["regex"] >> pattern;
+  regex = boost::regex(pattern);
+
+  if (const YAML::Node *pName =yaml_attributes.FindValue("family_replacement"))
+    overrides.family = pName->to<std::string>();
+  if (const YAML::Node *pName =yaml_attributes.FindValue("v1_replacement"))
+    *pName >> overrides.major;
+  if (const YAML::Node *pName =yaml_attributes.FindValue("v2_replacement"))
+    *pName >> overrides.minor;
+}
+
+
+
+Browser BrowserParser::Parse(const std::string &user_agent_string) {
+  Browser browser;
+  using namespace std;
+
+  boost::smatch result;
+  if (boost::regex_search(user_agent_string.begin(), user_agent_string.end(), result, regex)) {
+    if (overrides.family.empty() && result.size()>1)
+      browser.family = result[1].str();
+    else {
+      browser.family = overrides.family;
+      boost::replace_all(browser.family, "$1", result[1].str());
+    }
+
+    // If the group is not found, use the override value even if it is blank
+
+    if (overrides.major.empty()&&result.size()>2)
+      browser.major = result[2].str();
+    else
+      browser.major = overrides.major;
+
+    if (overrides.minor.empty()&&result.size()>3)
+      browser.minor = result[3].str();
+    else
+      browser.minor = overrides.minor;
+
+    if (overrides.patch.empty()&&result.size()>4)
+      browser.patch = result[4].str();
+    else
+      browser.patch = overrides.patch;
+
+    return browser;
+  }
+
+  return browser;
+
+}
+
+OperatingSystemParser::OperatingSystemParser(const YAML::Node &yaml_attributes) {
+  yaml_attributes["regex"] >> pattern;
+  regex = boost::regex(pattern);
+
+  if (const YAML::Node *pName =yaml_attributes.FindValue("os_replacement"))
+    *pName >> overrides.os;
+  if (const YAML::Node *pName =yaml_attributes.FindValue("os_v1_replacement"))
+    *pName >> overrides.major;
+  if (const YAML::Node *pName =yaml_attributes.FindValue("os_v2_replacement"))
+    *pName >> overrides.minor;
+}
+
+OperatingSystem OperatingSystemParser::Parse(const std::string &user_agent_string) {
+  OperatingSystem os;
+  using namespace std;
+
+  boost::smatch result;
+  if (boost::regex_search(user_agent_string.begin(), user_agent_string.end(), result, regex)) {
+    if (overrides.os.empty() && result.size()>1)
+      os.os = result[1].str();
+    else {
+      os.os = overrides.os;
+      boost::replace_all(os.os, "$1", result[1].str());
+    }
+
+    // If the group is not found, use the override value even if it is blank
+
+    if (overrides.major.empty()&&result.size()>2)
+      os.major = result[2].str();
+    else
+      os.major = overrides.major;
+
+    if (overrides.minor.empty()&&result.size()>3)
+      os.minor = result[3].str();
+    else
+      os.minor = overrides.minor;
+
+    if (overrides.patch.empty()&&result.size()>4)
+      os.patch = result[4].str();
+    else
+      os.patch = overrides.patch;
+
+    if (overrides.patch_minor.empty()&&result.size()>5)
+      os.patch_minor = result[5].str();
+    else
+      os.patch_minor = overrides.patch_minor;
+
+    return os;
+  }
+  return os;
+}
+
+DeviceParser::DeviceParser(const YAML::Node &yaml_attributes) {
+  yaml_attributes["regex"] >> pattern;
+  regex = boost::regex(pattern);
+
+  if (const YAML::Node *pName=yaml_attributes.FindValue("device_replacement"))
+    *pName >> overrides;
+}
+
+Device DeviceParser::Parse(const std::string &user_agent_string) {
+  Device device;
+  using namespace std;
+
+  boost::smatch result;
+  if (boost::regex_search(user_agent_string.begin(), user_agent_string.end(), result, regex)) {
+    if (overrides.empty() && result.size()>1)
+      device = result[1].str();
+    else {
+      device = overrides;
+      boost::replace_all(device, "$1", result[1].str());
+    }
+
+    return device;
+  }
+
+  return device;
+}
+
+
+
+template<class ParserType>
+static std::vector<ParserType> ParseYaml(const YAML::Node &yaml_regexes) {
+  std::vector<ParserType> parsers;
+
+  for (YAML::Iterator i=yaml_regexes.begin(); i!=yaml_regexes.end(); i++) {
+    ParserType parser(*i);
+
+    parsers.push_back(parser);
+  }
+
+  return parsers;
+}
+
+
+Parser::Parser(const std::string &yaml_file) {
+  std::ifstream in(yaml_file.c_str());
+  if (!in.good()) {
+    std::cerr << "Could not open YAML file" << yaml_file << std::endl;
+    return;
+  }
+
+  YAML::Parser parser(in);
+
+  YAML::Node doc;
+  parser.GetNextDocument(doc);
+
+  _browser_parsers = ParseYaml<BrowserParser>(doc["user_agent_parsers"]);
+  _os_parsers = ParseYaml<OperatingSystemParser>(doc["os_parsers"]);
+  _device_parsers = ParseYaml<DeviceParser>(doc["device_parsers"]);
+
+}
+
+UserAgent Parser::Parse(const std::string &user_agent_string) {
+  UserAgent user_agent;
+
+  user_agent.browser.family = "Other";
+  user_agent.os.os = "Other";
+  user_agent.device = "Other";
+
+  for (std::vector<BrowserParser>::iterator i=_browser_parsers.begin(); i!=_browser_parsers.end(); i++) {
+    Browser browser = i->Parse(user_agent_string);
+    if (!browser.family.empty()) {
+      user_agent.browser = browser;
+      break;
+    }
+
+  }
+
+  for (std::vector<OperatingSystemParser>::iterator i=_os_parsers.begin(); i!=_os_parsers.end(); i++) {
+    OperatingSystem os = i->Parse(user_agent_string);
+    if (!os.os.empty()) {
+      user_agent.os = os;
+      break;
+    }
+
+  }
+
+  for (std::vector<DeviceParser>::iterator i=_device_parsers.begin(); i!=_device_parsers.end(); i++) {
+    Device device = i->Parse(user_agent_string);
+    if (!device.empty()) {
+      user_agent.device = device;
+      break;
+    }
+
+  }
+
+
+
+  return user_agent;
+}
+
+}
+

--- a/cpp/ua_parser.h
+++ b/cpp/ua_parser.h
@@ -1,0 +1,147 @@
+/*
+# Copyright 2013 Andrew Punch
+#
+# Licensed under the Apache License, Version 2.0 (the 'License')
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/
+
+#ifndef __UA_PARSER_H__
+#define __UA_PARSER_H__
+
+#include <string>
+#include <vector>
+#include <boost/regex.hpp>
+#include <yaml-cpp/yaml.h>
+
+namespace ua_parser {
+class Browser {
+ public:
+  std::string family;
+  std::string major;
+  std::string minor;
+  std::string patch;
+  std::string patch_minor;
+
+  bool operator==(const Browser &rhs) const {
+    return family==rhs.family
+           && major==rhs.major
+           && minor==rhs.minor
+           && patch==rhs.patch
+           && patch_minor==rhs.patch_minor;
+  }
+
+
+};
+
+
+inline std::ostream& operator<<(std::ostream &o, const Browser &browser) {
+  return o <<"Browser: ("
+         << browser.family<<","
+         <<browser.major<<","
+         <<browser.minor<<","
+         <<browser.patch<<","
+         <<browser.patch_minor<<") ";
+}
+
+
+class OperatingSystem {
+ public:
+  std::string os;
+  std::string major;
+  std::string minor;
+  std::string patch;
+  std::string patch_minor;
+
+  bool operator==(const OperatingSystem &rhs) const {
+    return os==rhs.os
+           && major==rhs.major
+           && minor==rhs.minor
+           && patch==rhs.patch
+           && patch_minor==rhs.patch_minor;
+  }
+};
+
+inline std::ostream& operator<<(std::ostream &o, const OperatingSystem &os) {
+  return o<<"OS: ("
+         <<os.os<<","
+         <<os.major<<","
+         <<os.minor<<","
+         <<os.patch<<","
+         <<os.patch_minor<<") ";
+}
+
+
+typedef std::string Device;
+
+class BrowserParser {
+ public:
+  BrowserParser(const YAML::Node &yaml_attributes);
+  Browser Parse(const std::string &user_agent_string);
+
+  std::string pattern;
+  boost::regex regex;
+  Browser overrides;
+};
+
+
+class OperatingSystemParser {
+ public:
+  OperatingSystemParser(const YAML::Node &yaml_attributes);
+  OperatingSystem Parse(const std::string &user_agent_string);
+
+  std::string pattern;
+  boost::regex regex;
+  OperatingSystem overrides;
+};
+
+class DeviceParser {
+ public:
+  DeviceParser(const YAML::Node &yaml_attributes);
+  Device Parse(const std::string &user_agent_string);
+  std::string pattern;
+  boost::regex regex;
+  Device overrides;
+};
+
+
+class UserAgent {
+ public:
+  Browser browser;
+  OperatingSystem os;
+  Device device;
+  std::string user_agent_string;
+
+};
+
+inline std::ostream& operator<<(std::ostream &o, UserAgent &ua) {
+  return o  <<ua.browser
+         <<ua.os
+         <<"Device: ("<<ua.device<<")";
+}
+
+
+class Parser {
+ public:
+  Parser(const std::string &yaml_file);
+  UserAgent Parse(const std::string &user_agent_string);
+
+ private:
+  std::vector<BrowserParser> _browser_parsers;
+  std::vector<OperatingSystemParser> _os_parsers;
+  std::vector<DeviceParser> _device_parsers;
+};
+
+
+}
+
+
+#endif

--- a/cpp/ua_parser_test.cpp
+++ b/cpp/ua_parser_test.cpp
@@ -1,0 +1,161 @@
+/*
+# Copyright 2013 Andrew Punch
+#
+# Licensed under the Apache License, Version 2.0 (the 'License')
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/
+
+#include <string>
+#include <fstream>
+#include <gtest/gtest.h>
+#include "ua_parser.h"
+
+static const std::string TEST_RESOURCES_DIR="../test_resources/";
+
+class UaParserTest : public testing::Test {
+ protected:
+  bool yaml_isnull(const YAML::Node &node) {
+    return node.Type()==YAML::NodeType::Null;
+  }
+
+  void runUserAgentTestsFromYAML(const std::string &file_name) {
+    std::ifstream in(file_name.c_str());
+    if (!in.good()) {
+      FAIL() << "Could not open YAML file" << file_name;
+      return;
+    }
+
+    YAML::Parser parser(in);
+
+    YAML::Node doc;
+    parser.GetNextDocument(doc);
+
+    const YAML::Node &test_cases = doc["test_cases"];
+    for (YAML::Iterator i=test_cases.begin(); i!=test_cases.end(); i++) {
+      // Inputs to Parse()
+      const YAML::Node& test_case = *i;
+      std::string user_agent_string = test_case["user_agent_string"].to<std::string>();
+
+      // The expected results
+      ua_parser::Browser expected;
+      if (!yaml_isnull(test_case["family"])) expected.family = test_case["family"].to<std::string>();
+      if (!yaml_isnull(test_case["major"]))  expected.major  = test_case["major"].to<std::string>();
+      if (!yaml_isnull(test_case["minor"]))  expected.minor  = test_case["minor"].to<std::string>();
+      if (!yaml_isnull(test_case["patch"]))  expected.patch  = test_case["patch"].to<std::string>();
+
+      // js_ua not supported
+      if (test_case.FindValue("js_ua"))
+        continue;
+
+      ua_parser::Parser user_agent_parser("../regexes.yaml");
+      ua_parser::UserAgent result = user_agent_parser.Parse(user_agent_string);
+      EXPECT_EQ(expected, result.browser)<<user_agent_string;
+    }
+  }
+
+  void runOSTestsFromYAML(const std::string &file_name) {
+    std::ifstream in(file_name.c_str());
+    if (!in.good()) {
+      FAIL() << "Could not open YAML file" << file_name;
+      return;
+    }
+
+    YAML::Parser parser(in);
+
+    YAML::Node doc;
+    parser.GetNextDocument(doc);
+
+    const YAML::Node &test_cases = doc["test_cases"];
+
+    for (YAML::Iterator i=test_cases.begin(); i!=test_cases.end(); i++) {
+      // Inputs to Parse()
+      const YAML::Node &test_case = *i;
+      std::string user_agent_string = test_case["user_agent_string"].to<std::string>();
+
+      // The expected results
+      ua_parser::OperatingSystem expected;
+      if (!yaml_isnull(test_case["family"])) expected.os = test_case["family"].to<std::string>();
+      if (!yaml_isnull(test_case["major"]))  expected.major  = test_case["major"].to<std::string>();
+      if (!yaml_isnull(test_case["minor"]))  expected.minor  = test_case["minor"].to<std::string>();
+      if (!yaml_isnull(test_case["patch"]))  expected.patch  = test_case["patch"].to<std::string>();
+      if (!yaml_isnull(test_case["patch_minor"]))  expected.patch_minor = test_case["patch_minor"].to<std::string>();
+
+      ua_parser::Parser user_agent_parser("../regexes.yaml");
+      ua_parser::UserAgent result = user_agent_parser.Parse(user_agent_string);
+      EXPECT_EQ(result.os, expected) << user_agent_string;
+    }
+  }
+
+  void runDeviceTestsFromYAML(const std::string &file_name) {
+    std::ifstream in(file_name.c_str());
+    if (!in.good()) {
+      FAIL() << "Could not open YAML file" << file_name;
+      return;
+    }
+
+    YAML::Parser parser(in);
+
+    YAML::Node doc;
+    parser.GetNextDocument(doc);
+
+    const YAML::Node &test_cases = doc["test_cases"];
+
+    for (YAML::Iterator i=test_cases.begin(); i!=test_cases.end(); i++) {
+      const YAML::Node &test_case = *i;
+      // Inputs to Parse()
+      std::string user_agent_string = test_case["user_agent_string"].to<std::string>();
+
+      // The expected results
+      ua_parser::Device expected = test_case["family"].to<std::string>();
+
+      ua_parser::Parser user_agent_parser("../regexes.yaml");
+      ua_parser::UserAgent result = user_agent_parser.Parse(user_agent_string);
+      EXPECT_EQ(result.device, expected)<<user_agent_string;
+    }
+  }
+
+
+
+};
+
+
+TEST_F(UaParserTest, TestBrowserscopeStrings) {
+  runUserAgentTestsFromYAML(
+    TEST_RESOURCES_DIR+"test_user_agent_parser.yaml");
+}
+
+
+TEST_F(UaParserTest, TestBrowserscopeStringsOS) {
+  runOSTestsFromYAML(
+    TEST_RESOURCES_DIR+"test_user_agent_parser_os.yaml");
+}
+
+TEST_F(UaParserTest, TestStringsOS) {
+  runOSTestsFromYAML(
+    TEST_RESOURCES_DIR+"additional_os_tests.yaml");
+}
+
+TEST_F(UaParserTest, TestStringsDevice) {
+  runDeviceTestsFromYAML(
+    TEST_RESOURCES_DIR+"test_device.yaml");
+}
+
+TEST_F(UaParserTest, TestMozillaStrings) {
+  runUserAgentTestsFromYAML(
+    TEST_RESOURCES_DIR+"firefox_user_agent_strings.yaml");
+}
+
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Initial implementation in C++. 

Known issues:
- js_ua is not supported
- Performance of running numerous regexes for each user agent is still an issue (as much as any other platform)
- TODO: make install
- TODO: make package
