### PR TITLE
+ Optimize the regexes for spaces

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -82,7 +82,7 @@ user_agent_parsers:
   # http://luakit.org/projects/luakit/
   - regex: '(luakit)'
     family_replacement: 'LuaKit'
-    
+
   # Snowshoe
   - regex: '(Snowshoe)/(\d+)\.(\d+).(\d+)'
 
@@ -235,10 +235,10 @@ user_agent_parsers:
   - regex: '(iRider|Crazy Browser|SkipStone|iCab|Lunascape|Sleipnir|Maemo Browser) (\d+)\.(\d+)\.(\d+)'
   # Browser major_version.minor_version (space instead of slash)
   - regex: '(iCab|Lunascape|Opera|Android|Jasmine|Polaris) (\d+)\.(\d+)\.?(\d+)?'
-  
+
   # Kindle WebKit
   - regex: '(Kindle)/(\d+)\.(\d+)'
-  
+
   # weird android UAs
   - regex: '(Android) Donut'
     v1_replacement: '1'
@@ -288,7 +288,7 @@ user_agent_parsers:
     family_replacement: 'NetFront'
   - regex: '(PlayStation Vita)'
     family_replacement: 'NetFront NX'
-  
+
   - regex: 'AppleWebKit.+ (NX)/(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'NetFront NX'
   - regex: '(Nintendo 3DS)'
@@ -329,7 +329,7 @@ user_agent_parsers:
     family_replacement: 'Mobile Safari'
 
   - regex: '(AvantGo) (\d+).(\d+)'
-  
+
   - regex: '(OneBrowser)/(\d+).(\d+)'
     family_replacement: 'ONE Browser'
 
@@ -418,7 +418,7 @@ user_agent_parsers:
 
   - regex: '(Teleca)'
     family_replacement: 'Teleca Browser'
-    
+
   - regex: '(Phantom)/V(\d+)\.(\d+)'
     family_replacement: 'Phantom Browser'
 
@@ -543,7 +543,7 @@ os_parsers:
   # (very) roughly ordered in terms of frequency of occurence of regex (win xp currently most frequent, etc)
   ##########
 
-  - regex: '(Windows (?:NT 5\.2|NT 5\.1))'
+  - regex: '(Windows ?(?:NT ?5\.2|NT ?5\.1))'
     os_replacement: 'Windows XP'
 
   # ie mobile des ktop mode
@@ -551,29 +551,29 @@ os_parsers:
   - regex: '(XBLWP7)'
     os_replacement: 'Windows Phone'
 
-  - regex: '(Windows NT 6\.1)'
+  - regex: '(Windows ?NT ?6\.1)'
     os_replacement: 'Windows 7'
 
-  - regex: '(Windows NT 6\.0)'
+  - regex: '(Windows ?NT ?6\.0)'
     os_replacement: 'Windows Vista'
 
-  - regex: '(Win 9x 4\.90)'
+  - regex: '(Win ?9x ?4\.90)'
     os_replacement: 'Windows Me'
 
-  - regex: '(Windows 98|Windows XP|Windows ME|Windows 95|Windows CE|Windows 7|Windows NT 4\.0|Windows Vista|Windows 2000|Windows 3.1)'
+  - regex: '(Windows ?98|Windows ?XP|Windows ?ME|Windows ?95|Windows ?CE|Windows ?7|Windows ?NT ?4\.0|Windows ?Vista|Windows ?2000|Windows ?3.1)'
 
-  - regex: '(Windows NT 6\.2; ARM;)'
+  - regex: '(Windows ?NT ?6\.2; ?ARM;)'
     os_replacement: 'Windows RT'
 
   # is this a spoof or is nt 6.2 out and about in some capacity?
-  - regex: '(Windows NT 6\.2)'
+  - regex: '(Windows ?NT ?6\.2)'
     os_replacement: 'Windows 8'
 
-  - regex: '(Windows NT 5\.0)'
+  - regex: '(Windows ?NT ?5\.0)'
     os_replacement: 'Windows 2000'
 
-  - regex: '(Windows Phone) (\d+)\.(\d+)'
-  - regex: '(Windows Phone) OS (\d+)\.(\d+)'
+  - regex: '(Windows ?Phone) ?(\d+)\.(\d+)'
+  - regex: '(Windows ?Phone) ?OS ?(\d+)\.(\d+)'
   - regex: '(Windows ?Mobile)'
     os_replacement: 'Windows Mobile'
 
@@ -593,8 +593,8 @@ os_parsers:
   # Mac OS
   # http://en.wikipedia.org/wiki/Mac_OS_X#Versions
   ##########
-  - regex: '(Mac OS X) (\d+)[_.](\d+)(?:[_.](\d+))?'
-  
+  - regex: '(Mac ?OS ?X) ?(\d+)[_.](\d+)(?:[_.](\d+))?'
+
   # IE on Mac doesn't specify version number
   - regex: 'Mac_PowerPC'
     os_replacement: 'Mac OS'
@@ -602,17 +602,17 @@ os_parsers:
   # builds before tiger don't seem to specify version?
 
   # ios devices spoof (mac os x), so including intel/ppc prefixes
-  - regex: '(?:PPC|Intel) (Mac OS X)'
+  - regex: '(?:PPC|Intel) ?(Mac ?OS ?X)'
 
   ##########
   # iOS
   # http://en.wikipedia.org/wiki/IOS_version_history
   ##########
-  - regex: '(CPU OS|iPhone OS) (\d+)_(\d+)(?:_(\d+))?'
+  - regex: '(CPU ?OS|iPhone ?OS) ?(\d+)_(\d+)(?:_(\d+))?'
     os_replacement: 'iOS'
 
   # remaining cases are mostly only opera uas, so catch opera as to not catch iphone spoofs
-  - regex: '(iPhone|iPad|iPod); Opera'
+  - regex: '(iPhone|iPad|iPod); ?Opera'
     os_replacement: 'iOS'
 
   # few more stragglers
@@ -651,10 +651,10 @@ os_parsers:
     os_replacement: 'Symbian^3 Belle'
   - regex: '(Symbian/3)'
     os_replacement: 'Symbian^3'
-  - regex: '(Series 60|SymbOS|S60)'
+  - regex: '(Series ?60|SymbOS|S60)'
     os_replacement: 'Symbian OS'
   - regex: '(MeeGo)'
-  - regex: 'Symbian [Oo][Ss]'
+  - regex: 'Symbian ?[Oo][Ss]'
     os_replacement: 'Symbian OS'
   - regex: 'Series40;'
     os_replacement: 'Nokia Series 40'
@@ -700,7 +700,7 @@ os_parsers:
   - regex: '(GoogleTV)/[\da-z]+'
 
   - regex: '(WebTV)/(\d+).(\d+)'
-  
+
   ##########
   # Misc mobile
   ##########
@@ -814,7 +814,7 @@ device_parsers:
   - regex: '(Kindle)'
   - regex: '(Silk)/(\d+)\.(\d+)(?:\.([0-9\-]+))?'
     device_replacement: 'Kindle Fire'
-      
+
   #########
   # Android General Device Matching (far from perfect)
   #########
@@ -893,10 +893,10 @@ device_parsers:
 
   - regex: 'AdsBot-Google-Mobile'
     device_replacement: 'Spider'
-   
+
   - regex: 'Googlebot-Mobile/(\d+).(\d+)'
     device_replacement: 'Spider'
-    
+
   ##########
   # complete but probably catches spoofs
   # iSTUFF
@@ -918,7 +918,7 @@ device_parsers:
   - regex: 'acer_([A-Za-z0-9]+)_'
     device_replacement: 'Acer $1'
 
-  ##########   
+  ##########
   # Alcatel
   ##########
   - regex: 'ALCATEL-([A-Za-z0-9]+)'
@@ -1044,7 +1044,7 @@ device_parsers:
     device_replacement: 'Motorola $1'
   - regex: 'MOT\-([A-Za-z0-9]+)'
     device_replacement: 'Motorola $1'
-    
+
   ##########
   # nintendo
   ##########
@@ -1058,7 +1058,7 @@ device_parsers:
   ##########
   - regex: 'Pantech([A-Za-z0-9]+)'
     device_replacement: 'Pantech $1'
- 
+
   ##########
   # philips
   ##########
@@ -1117,4 +1117,3 @@ device_parsers:
   ##########
   - regex: '(bingbot|bot|borg|google(^tv)|yahoo|slurp|msnbot|msrbot|openbot|archiver|netresearch|lycos|scooter|altavista|teoma|gigabot|baiduspider|blitzbot|oegp|charlotte|furlbot|http%20client|polybot|htdig|ichiro|mogimogi|larbin|pompos|scrubby|searchsight|seekbot|semanticdiscovery|silk|snappy|speedy|spider|voila|vortex|voyager|zao|zeal|fast\-webcrawler|converacrawler|dataparksearch|findlinks|crawler)'
     device_replacement: 'Spider'
-


### PR DESCRIPTION
I found that sometimes, ua-parser can't parse some UA like:
Mozilla/5.0(compatible;MSIE9.0;WindowsPhoneOS7.5;Trident/5.0;IEMobile/9.0;NOKIA;Lumia820)

just because the corresponding regexes contain space:
Windows Phone OS.

So i would like to add space in some regexes in order to detect better the uas.
