### PR TITLE
Better detection of Firefox browsers on tablets (Firefox OS and Android)

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -678,7 +678,7 @@ os_parsers:
   ##########
   # Firefox OS
   ##########
-  - regex: '\(Mobile;.+Firefox/\d+\.\d+'
+  - regex: '\((?:Mobile|Tablet);.+Firefox/\d+\.\d+'
     os_replacement: 'Firefox OS'
 
   ##########

--- a/test_resources/test_device.yaml
+++ b/test_resources/test_device.yaml
@@ -213,6 +213,9 @@ test_cases:
   - user_agent_string: 'Mozilla/5.0 (Mobile; rv:15.0) Gecko/15.0 Firefox/15.0'
     family: 'Other'
 
+  - user_agent_string: 'Mozilla/5.0 (Tablet; rv:29.0) Gecko/29.0 Firefox/29.0'
+    family: 'Other'
+
   - user_agent_string: 'PantechP6010/JNUS11072011 BMP/1.0.2 DeviceId/141020 NetFront/4.1 OMC/1.5.3 Profile/MIDP-2.1 Configuration/CLDC-1.1'
     family: 'Pantech P6010'
 

--- a/test_resources/test_user_agent_parser_os.yaml
+++ b/test_resources/test_user_agent_parser_os.yaml
@@ -217,6 +217,13 @@ test_cases:
     patch:
     patch_minor:
 
+  - user_agent_string: 'Mozilla/5.0 (Tablet; rv:29.0) Gecko/29.0 Firefox/29.0'
+    family: 'Firefox OS'
+    major:
+    minor:
+    patch:
+    patch_minor:
+
   - user_agent_string: 'Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10'
     family: 'iOS'
     major: '3'


### PR DESCRIPTION
This PR adds a "Firefox Tablet" family, similar to the already existing "Firefox Mobile" family. Also for Firefox OS tablets, `os.family` will now report "Firefox OS", rather than "Other".
