### PR TITLE
Fixed bug in 'formatVersion'

### DIFF
--- a/php/src/UAParser/Result/AbstractVersionedSoftware.php
+++ b/php/src/UAParser/Result/AbstractVersionedSoftware.php
@@ -23,6 +23,6 @@ abstract class AbstractVersionedSoftware extends AbstractSoftware
     /** @return string */
     protected function formatVersion()
     {
-        return join('.', array_filter(func_get_args()));
+		return join('.', array_filter(func_get_args(), function($value) {return $value !== null;}));
     }
 }


### PR DESCRIPTION
Version arguments with the value 0 where filtered out.
callback function added to prevent values that are not null to be filtered out.
