### PR TITLE
moved android device matching to bottom

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1063,6 +1063,8 @@ device_parsers:
     device_replacement: 'Samsung $1'
   - regex: 'SAMSUNG\; ([A-Za-z0-9\-]+)'
     device_replacement: 'Samsung $1'
+  - regex: 'SAMSUNG ([A-Za-z0-9\-]+)'
+    device_replacement: 'Samsung $1'
 
   ##########
   # Sega


### PR DESCRIPTION
I'm not sure if this is going to cause other problems, but I think the android general device matching needs moving below other regexs... its causing:

Mozilla/5.0 (Linux; Android 4.2.2; zh-cn; SAMSUNG-GT-I9508_TD/1.0 Android/4.2.2 Release/03.15.2013 Browser/AppleWebKit535.19 Build/JDQ39) ApplelWebkit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19

to return a device name of:

SAMSUNG-GT-I9508_TD/1.0 Android/4.2.2 Release/03.15.2013 Browser/AppleWebKit535.19

EDIT: this actually stops the following returning a device match for samsung devices with a UA like this: 

Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; SAMSUNG SM-T315/T315XXUAMG3 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30

So an additional samsung rule must be added to the samsung device group - I will add the change to this branch
- regex: 'SAMSUNG ([A-Za-z0-9-]+)'
  device_replacement: 'Samsung $1'
