### PR TITLE
Document jar building in pig directory

### DIFF
--- a/pig/README.md
+++ b/pig/README.md
@@ -6,8 +6,9 @@ The implementation uses the shared regex patterns and overrides from regexes.yam
 
 Build:
 ------
-
-    cd ../java ; mvn install
+    
+    cd pig
+    mvn install
     mvn package
 
 Usage:


### PR DESCRIPTION
Simple change to show the pig jar is built in the pig directory, not the java directory.
