### PR TITLE
Detect Windows NT 6.3 as Windows 8.1

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -574,18 +574,13 @@ os_parsers:
 
   - regex: '(Windows NT 6\.2; ARM;)'
     os_replacement: 'Windows RT'
-
-  # is this a spoof or is nt 6.2 out and about in some capacity?
   - regex: '(Windows NT 6\.2)'
     os_replacement: 'Windows 8'
 
-  # I assume that windows 6.3 ARM codename windows 8.1 ARM is windows RT in release name
   - regex: '(Windows NT 6\.3; ARM;)'
-    os_replacement: 'Windows RT'
-
-# I assume that windows 6.3 codename windows 8.1 is windows 8 in release name
+    os_replacement: 'Windows RT 8.1'
   - regex: '(Windows NT 6\.3)'
-    os_replacement: 'Windows 8'
+    os_replacement: 'Windows 8.1'
 
   - regex: '(Windows NT 5\.0)'
     os_replacement: 'Windows 2000'

--- a/test_resources/test_user_agent_parser_os.yaml
+++ b/test_resources/test_user_agent_parser_os.yaml
@@ -715,14 +715,14 @@ test_cases:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko'
-    family: 'Windows 8'
+    family: 'Windows 8.1'
     major:
     minor:
     patch:
     patch_minor:
 
   - user_agent_string: 'Mozilla/5.0 (Windows NT 6.3; ARM; WOW64; Trident/7.0; rv:11.0) like Gecko'
-    family: 'Windows RT'
+    family: 'Windows RT 8.1'
     major:
     minor:
     patch:


### PR DESCRIPTION
Unfortunately "Windows NT 6.3" is being detected as "Windows 8" but should be "Windows 8.1"
The ARM Version is named "Windows RT 8.1" accordingly (See http://windows.microsoft.com/en-us/windows/windows-rt-faq)
