### PR TITLE
Better detection of iOS from In-App Browsing

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -626,7 +626,7 @@ os_parsers:
   # iOS
   # http://en.wikipedia.org/wiki/IOS_version_history
   ##########
-  - regex: '(CPU OS|iPhone OS) (\d+)_(\d+)(?:_(\d+))?'
+  - regex: '(CPU OS|iPhone OS|CPU iPhone) (\d+)[_\.](\d+)(?:[_\.](\d+))?'
     os_replacement: 'iOS'
 
   # remaining cases are mostly only opera uas, so catch opera as to not catch iphone spoofs

--- a/test_resources/test_user_agent_parser_os.yaml
+++ b/test_resources/test_user_agent_parser_os.yaml
@@ -1092,3 +1092,23 @@ test_cases:
     patch:
     patch_minor:
 
+  - user_agent_string: 'Mozilla/5.0 (iPhone; U; CPU iPhone 6_1_4 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Mobile/7E18 Grindr/1.8.8 (iPhone5,2/6.1.4)'
+    family: 'iOS'
+    major: '6'
+    minor: '1'
+    patch: '4'
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (iPhone; U; CPU iPhone 7_0 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Mobile/7E18 Grindr/1.8.8 (iPhone3,1/7.0)'
+    family: 'iOS'
+    major: '7'
+    minor: '0'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'iTube 2.15 (iPhone; iPhone OS 7.0; en_US)'
+    family: 'iOS'
+    major: '7'
+    minor: '0'
+    patch:
+    patch_minor:


### PR DESCRIPTION
Regex detects iOS Version from UAs used by In-App Browsers (e.g. UIWebView ...)
