### PR TITLE
Enable $1 replacement within Java parser

### DIFF
--- a/java/src/main/java/ua_parser/OSParser.java
+++ b/java/src/main/java/ua_parser/OSParser.java
@@ -91,7 +91,11 @@ public class OSParser {
       int groupCount = matcher.groupCount();
 
       if (osReplacement != null) {
-        family = osReplacement;
+        if (osReplacement.contains("$1")) {
+          family = osReplacement.replaceAll("\\$1", matcher.group(1));
+        } else {
+          family = osReplacement;
+        }
       } else if (groupCount >= 1) {
         family = matcher.group(1);
       }


### PR DESCRIPTION
Tests for the java parser were failing, as "Windows $1" was reported
as OS in some tests instead of "Windows NT" [1]. We fix those tests by
implementing the $1 replacement akin to the Python parser.

[1]

[...]
Running ua_parser.ParserTest
Tests run: 9, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 5.151 sec <<< FAILURE!
Running ua_parser.UserAgentTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.017 sec
Running ua_parser.CachingParserTest
Tests run: 17, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 18.909 sec <<< FAILURE!

Results :

Failed tests:   testParseOS(ua_parser.ParserTest): Mozilla/5.0 (Windows U; Win NT 5.0; en-US; rv:1.8.0.2) Gecko/20060308 Firefox/1.5.0.2
  testCachedParseOS(ua_parser.CachingParserTest): Mozilla/5.0 (Windows U; Win NT 5.0; en-US; rv:1.8.0.2) Gecko/20060308 Firefox/1.5.0.2
  testParseOS(ua_parser.CachingParserTest): Mozilla/5.0 (Windows U; Win NT 5.0; en-US; rv:1.8.0.2) Gecko/20060308 Firefox/1.5.0.2
