### PR TITLE
Switch java versioning scheme to SNAPSHOTs before release

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,7 +4,7 @@
   <groupId>ua_parser</groupId>
   <artifactId>ua-parser</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>1.3.1-SNAPSHOT</version>
   <name>ua-parser</name>
   <url>https://github.com/tobie/ua-parser/</url>
   <properties>


### PR DESCRIPTION
While the java variant previously had SNAPSHOT builds after the
release (like

  x -> x-SNAPSHOT -> (x+1) -> (x+1)-SNAPSHOT

), the Java world typically has SNAPSHOT builds before the release
(like

  x-SNAPSHOT -> x -> (x+1)-SNAPSHOT -> (x+1)

). We bump to a new unencumbered version, to be able to switch to the
usual Java versioning scheme.
