### PR TITLE
C# console project to top makes it default startup

### DIFF
--- a/csharp/UAParser.sln
+++ b/csharp/UAParser.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UAParser.ConsoleApp", "UAParser.ConsoleApp\UAParser.ConsoleApp.csproj", "{280CF383-6A6E-487B-9D25-281C98F3A7C8}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UAParser", "UAParser\UAParser.csproj", "{83C63BEA-1859-4DD5-AE08-9A0FEC269B17}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Items", "Items", "{AB82C54B-9D7F-4FD6-B3F3-05589F11E4C2}"
@@ -9,8 +11,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Items", "Items", "{AB82C54B
 		build.proj = build.proj
 		PublicKey.snk = PublicKey.snk
 	EndProjectSection
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UAParser.ConsoleApp", "UAParser.ConsoleApp\UAParser.ConsoleApp.csproj", "{280CF383-6A6E-487B-9D25-281C98F3A7C8}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UAParser.Tests", "UAParser.Tests\UAParser.Tests.csproj", "{967089C7-1D9D-453E-AAA8-ED26BCECCE20}"
 EndProject


### PR DESCRIPTION
Moving the console app C# project to the top in solution file so that Visual Studio makes it automatically the default start-up project. The other projects in the solution are libraries so one cannot simply open the solution and hit F5. It's a small thing but makes for a good “first impressions” when checking out the project. Takes out the guess work. One just loads and goes!
