### PR TITLE
C# console app rehashed as a useful UA parsing tool

### DIFF
--- a/csharp/UAParser.ConsoleApp/Program.cs
+++ b/csharp/UAParser.ConsoleApp/Program.cs
@@ -1,22 +1,41 @@
-﻿using System;
-
-namespace UAParser.ConsoleApp
+﻿namespace UAParser.ConsoleApp
 {
-  class Program
+  using System;
+  using System.Linq;
+
+  static class Program
   {
     static void Main(string[] args)
     {
-      String uaString = "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-us) AppleWebKit/533.18.1 (KHTML, like Gecko) Version/5.0.2 Safari/533.18.5";
+      if (args.Any(arg => arg == "-?" || arg == "-h" || arg == "--help"))
+      {
+          Help();
+          return;
+      }
 
-      Parser uaParser = Parser.GetDefault();
+      var uaParser = Parser.GetDefault();
+      string uaString;
+      while ((uaString = Console.In.ReadLine()) != null)
+      {
+          uaString = uaString.Trim();
+          if (uaString.Length == 0)
+            continue;
+          var c = uaParser.Parse(uaString);
+          Console.WriteLine("Agent : {0}", c.UserAgent);
+          Console.WriteLine("OS    : {0}", c.OS);
+          Console.WriteLine("Device: {0}", c.Device);
+      }
+    }
 
-      ClientInfo c = uaParser.Parse(uaString);
+    static void Help()
+    {
+            Console.WriteLine(@"UAParser
+Copyright 2012 " + "S\u00f8ren Enem\u00e6rke" + @"
+https://github.com/tobie/ua-parser
 
-      Console.WriteLine(c.UserAgent);  //Safari 5.0.2
-      Console.WriteLine(c.OS); // Mac OS X 10.6.5
-      Console.WriteLine(c.Device); //
-
-      Console.ReadLine();
+This application accepts user agent strings (one per line) from standard 
+input, parses them and then emits the identified agent, operating system and 
+device for each string.");
     }
   }
 }


### PR DESCRIPTION
The console app in the C# solution was hard-coded to a single demo case. This pull request proposes to turn it into a useful and dynamic utility. It now accepts UA strings (one per line) from standard input, parses them and then emits the identified agent, operating system and device for UA each string. Because it just uses standard input, one can also pipe a file of UA strings for ad-hoc testing.
