### PR TITLE
use file-embed for regexes.yaml

### DIFF
--- a/haskell/src/Web/UAParser.hs
+++ b/haskell/src/Web/UAParser.hs
@@ -7,8 +7,10 @@ module Web.UAParser
     -- * Readying parser
       UAConfig
     , loadUAParser
+    , compiledConfig
     -- * Parsing browser (user agent)
     , parseUA
+    , parseUACompiled
     , UAResult (..)
     , uarVersion
     -- * Parsing OS

--- a/haskell/ua-parser.cabal
+++ b/haskell/ua-parser.cabal
@@ -1,6 +1,6 @@
 Name:                ua-parser
 Description:         Please refer to the git/github README on the project for example usage.
-Version:             0.4
+Version:             0.4.1
 Synopsis:            A library for parsing User-Agent strings, official Haskell port of ua-parser
 License:             BSD3
 License-file:        LICENSE
@@ -36,6 +36,7 @@ Library
     , filepath
     , data-default
     , syb
+    , file-embed
 
   ghc-options: -O2 -Wall  
 


### PR DESCRIPTION
@ozataman this uses file-embed to avoid having to lug regexes.yaml around with the resulting binary. Another nice side-effect is there is no more need for any IO in the form of loadConfig.
