### PR TITLE
GooglePlusBot regexp modify

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -184,7 +184,7 @@ user_agent_parsers:
     family_replacement: 'TwitterBot'
 
   # Google Plus
-  - regex: 'Google.*/\+/web/snippet'
+  - regex: 'Google \(\+.*\)'
     family_replacement: 'GooglePlusBot'
 
   # Rackspace Monitoring

--- a/test_resources/test_user_agent_parser.yaml
+++ b/test_resources/test_user_agent_parser.yaml
@@ -254,6 +254,12 @@ test_cases:
     minor:
     patch:
 
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 6.1; rv:6.0) Gecko/20110814 Firefox/6.0 Google (+)'
+    family: 'GooglePlusBot'
+    major:
+    minor:
+    patch:
+
   - user_agent_string: 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.1pre) Gecko/20090717 Ubuntu/9.04 (jaunty) Shiretoko/3.5.1pre'
     family: 'Firefox (Shiretoko)'
     major: '3'


### PR DESCRIPTION
Google plus new pattern: `Google \(\+.*\)`
`/Google \(\+.*\)/.test('Mozilla/5.0 (Windows NT 6.1; rv:6.0) Gecko/20110814 Firefox/6.0 Google (+)')` => true
`/Google \(\+.*\)/.test('Google (+https://developers.google.com/+/web/snippet/)')` => true
