### PR TITLE
New entries for Spiders, Espial Smart TV, plus fixes for Windows Phones ...

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -247,6 +247,18 @@ user_agent_parsers:
   # Chrome/Chromium/major_version.minor_version
   - regex: '(Chromium|Chrome)/(\d+)\.(\d+)'
 
+  ##########
+  # IE Mobile needs to happen before Android to catch cases such as:
+  # Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 920)...
+  # Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 920; ANZ821)...
+  # Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 920; Orange)...
+  # Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 920; Vodafone)...
+  ##########
+  
+  # IE Mobile
+  - regex: '(IEMobile)[ /](\d+)\.(\d+)'
+    family_replacement: 'IE Mobile'
+  
   # Browser major_version.minor_version.beta_version (space instead of slash)
   - regex: '(iRider|Crazy Browser|SkipStone|iCab|Lunascape|Sleipnir|Maemo Browser) (\d+)\.(\d+)\.(\d+)'
   # Browser major_version.minor_version (space instead of slash)
@@ -275,9 +287,6 @@ user_agent_parsers:
   - regex: '(Android) Honeycomb'
     v1_replacement: '3'
 
-  # IE Mobile
-  - regex: '(IEMobile)[ /](\d+)\.(\d+)'
-    family_replacement: 'IE Mobile'
   # desktop mode
   # http://www.anandtech.com/show/3982/windows-phone-7-review
   - regex: '(MSIE) (\d+)\.(\d+).*XBLWP7'
@@ -444,6 +453,9 @@ user_agent_parsers:
   - regex: 'Trident(.*)rv.(\d+)\.(\d+)'
     family_replacement: 'IE'
 
+  # Espial
+  - regex: '(Espial)/(\d+)(?:\.(\d+))?(?:\.(\d+))?'  
+
  # Apple Mail
 
   # apple mail - not directly detectable, have it after Safari stuff
@@ -522,6 +534,16 @@ os_parsers:
   - regex: 'HbbTV/\d+\.\d+\.\d+ \(.*; ?([a-zA-Z]+) ?;.*(201[1-9]).*\)'
 
   ##########
+  # @note: Windows Phone needs to come before Windows NT 6.1 *and* before Android to catch cases such as:
+  # Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 920)...
+  # Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 920; ANZ821)...
+  # Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 920; Orange)...
+  # Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 920; Vodafone)...
+  ##########
+
+  - regex: '(Windows Phone) (?:OS[ /])?(\d+)\.(\d+)'
+
+  ##########
   # Android
   # can actually detect rooted android os. do we care?
   ##########
@@ -577,8 +599,7 @@ os_parsers:
   - regex: '(XBLWP7)'
     os_replacement: 'Windows Phone'
 
-  # @note: These need to come before Windows NT 6.1
-  - regex: '(Windows Phone) (?:OS[ /])?(\d+)\.(\d+)'
+  # @note: This needs to come before Windows NT 6.1
   - regex: '(Windows ?Mobile)'
     os_replacement: 'Windows Mobile'
 
@@ -988,6 +1009,12 @@ device_parsers:
     device_replacement: 'Spider'
 
   - regex: 'Googlebot/\d+.\d+'
+    device_replacement: 'Spider'
+
+  - regex: 'NING/(\d+).(\d+)'
+    device_replacement: 'Spider'
+    
+  - regex: 'MsnBot-Media /(\d+).(\d+)'
     device_replacement: 'Spider'
 
   ##########

--- a/test_resources/test_device.yaml
+++ b/test_resources/test_device.yaml
@@ -347,3 +347,9 @@ test_cases:
 
   - user_agent_string: 'Innovazion Crawler/Nutch-1.7'
     family: 'Spider'
+
+  - user_agent_string: 'NING/1.0'
+    family: 'Spider'
+
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/534+ (KHTML, like Gecko) MsnBot-Media /1.0b'
+    family: 'Spider'

--- a/test_resources/test_user_agent_parser.yaml
+++ b/test_resources/test_user_agent_parser.yaml
@@ -308,6 +308,12 @@ test_cases:
     minor: '1'
     patch:
 
+  - user_agent_string: 'Mozilla/5.0 (DTV) AppleWebKit/531.2+ (KHTML, like Gecko) Espial/6.1.6 AQUOSBrowser/2.0 (US01DTV;V;0001;0001)'
+    family: 'Espial'
+    major: '6'
+    minor: '1'
+    patch: '6'
+
   - user_agent_string: 'iBrowser/Mini2.8 (Nokia5130c-2/07.97)'
     family: 'iBrowser Mini'
     major: '2'
@@ -982,6 +988,13 @@ test_cases:
     family: 'IE Mobile'
     major: '8'
     minor: '12'
+    patch:
+    patch_minor:
+
+  - user_agent_string: 'Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 920)'
+    family: 'IE Mobile'
+    major: '11'
+    minor: '0'
     patch:
     patch_minor:
 

--- a/test_resources/test_user_agent_parser_os.yaml
+++ b/test_resources/test_user_agent_parser_os.yaml
@@ -1582,6 +1582,13 @@ test_cases:
     patch:
     patch_minor:
 
+  - user_agent_string: 'Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 920; ANZ821)'
+    family: 'Windows Phone'
+    major: '8'
+    minor: '1'
+    patch:
+    patch_minor:
+
   - user_agent_string: 'Mozilla/5.0 (Windows U; Win NT 5.0; en-US; rv:1.8.0.2) Gecko/20060308 Firefox/1.5.0.2'
     family: 'Windows NT'
     major:


### PR DESCRIPTION
...with Android in the UA string.

The Spiders are NING and MsnBot-Media

Espial is a new Smart TV Provider,

And certain Lumia Phones are generating user agent strings that contain the text: 'Android', which is spoofing the parser into thinking these are Android devices when they are in fact Windows Phones.
