### PR TITLE
handle $1 replacements in java parser

### DIFF
--- a/java/src/main/java/ua_parser/OSParser.java
+++ b/java/src/main/java/ua_parser/OSParser.java
@@ -91,7 +91,13 @@ public class OSParser {
       int groupCount = matcher.groupCount();
 
       if (osReplacement != null) {
-        family = osReplacement;
+          if (groupCount >= 1) {
+              family = Pattern.compile("(" + Pattern.quote("$1") + ")")
+                              .matcher(osReplacement)
+                              .replaceAll(matcher.group(1));
+          } else { 
+              family = osReplacement; 
+          }
       } else if (groupCount >= 1) {
         family = matcher.group(1);
       }


### PR DESCRIPTION
This has been broken for a few months. This brings the java parser into test compliance.
