### PR TITLE
Fix #438 - Add fallback to avoid ImportError in Google App Engine (no pkg_resources)

### DIFF
--- a/py/ua_parser/user_agent_parser.py
+++ b/py/ua_parser/user_agent_parser.py
@@ -31,8 +31,6 @@ ROOT_DIR = os.path.abspath(os.path.dirname(__file__))
 DATA_DIR = os.path.abspath(os.path.join(ROOT_DIR, '..', 'data'))
 regex_dir = ROOT_DIR if os.path.exists(os.path.join(ROOT_DIR, 'regexes.yaml')) else DATA_DIR
 
-from pkg_resources import resource_filename
-
 
 class UserAgentParser(object):
     def __init__(self, pattern, family_replacement=None, v1_replacement=None, v2_replacement=None):
@@ -409,8 +407,13 @@ UA_PARSER_YAML = os.getenv("UA_PARSER_YAML")
 regexes = None
 
 if not UA_PARSER_YAML:
-    yamlPath = resource_filename(__name__, 'regexes.yaml')
-    json_path = resource_filename(__name__, 'regexes.json')
+    try:
+        from pkg_resources import resource_filename
+        yamlPath = resource_filename(__name__, 'regexes.yaml')
+        json_path = resource_filename(__name__, 'regexes.json')
+    except ImportError:
+        yamlPath = os.path.join(ROOT_DIR, 'regexes.yaml')
+        json_path = os.path.join(ROOT_DIR, 'regexes.json')
 else:
     import yaml
 


### PR DESCRIPTION
To avoid ImportError I moved the import inside a try/except block. This let the user define a UA_PARSER_YAML to avoid the exception or fallback in the previous code to load the json and yaml paths.
