### PR TITLE
experimental automata detection (needs discussion)

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1336,5 +1336,5 @@ device_parsers:
   ##########
   # Automata (experimental): intended to cover automated libraries or mirroring software that is not, itself, a crawler
   ##########
-  - regex: '(urllib|libww|Java/|(Apache|Jakarta Commons)-HttpClient|Twisted PageGetter|HTTrack|Scrapy|Wordpress|Wget)'
+  - regex: '(urllib|libww|Java/|(Apache|Jakarta Commons)-HttpClient|Twisted PageGetter|HTTrack|Scrapy|WordPress|Wget)'
     device_replacement: 'Reuser'

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1336,5 +1336,5 @@ device_parsers:
   ##########
   # Automata (experimental): intended to cover automated libraries or mirroring software that is not, itself, a crawler
   ##########
-  - regex: '(urllib|libww|Java/)|(Apache|Jakarta Commons)-HttpClient|Twisted PageGetter|HTTrack|Scrapy|Wordpress|Wget)'
+  - regex: '(urllib|libww|Java/|(Apache|Jakarta Commons)-HttpClient|Twisted PageGetter|HTTrack|Scrapy|Wordpress|Wget)'
     device_replacement: 'Reuser'

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1337,4 +1337,4 @@ device_parsers:
   # Automata (experimental): intended to cover automated libraries or mirroring software that is not, itself, a crawler
   ##########
   - regex: '(urllib|libww|Java/|(Apache|Jakarta Commons)-HttpClient|Twisted PageGetter|HTTrack|Scrapy|WordPress|Wget)'
-    device_replacement: 'Reuser'
+    device_replacement: 'Automata'

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1333,3 +1333,8 @@ device_parsers:
   - regex: '(bingbot|bot|borg|google(^tv)|yahoo|slurp|msnbot|msrbot|openbot|archiver|netresearch|lycos|scooter|altavista|teoma|gigabot|baiduspider|blitzbot|oegp|charlotte|furlbot|http%20client|polybot|htdig|ichiro|mogimogi|larbin|pompos|scrubby|searchsight|seekbot|semanticdiscovery|silk|snappy|speedy|spider|voila|vortex|voyager|zao|zeal|fast\-webcrawler|converacrawler|dataparksearch|findlinks|crawler|Netvibes|Sogou Pic Spider|ICC\-Crawler|Innovazion Crawler|Daumoa|EtaoSpider|A6\-Indexer|YisouSpider|Riddler|DBot|wsr\-agent|Xenu|SeznamBot|PaperLiBot|SputnikBot|CCBot|ProoXiBot|Scrapy|Genieo|Screaming Frog|YahooCacheSystem|CiBra|Nutch)'
     device_replacement: 'Spider'
 
+  ##########
+  # Automata (experimental): intended to cover automated libraries or mirroring software that is not, itself, a crawler
+  ##########
+  - regex: '(urllib|libww|Java/)|(Apache|Jakarta Commons)-HttpClient|Twisted PageGetter|HTTrack|Scrapy|Wordpress|Wget)'
+    device_replacement: 'Reuser'

--- a/test_resources/test_device.yaml
+++ b/test_resources/test_device.yaml
@@ -470,3 +470,33 @@ test_cases:
 
   - user_agent_string: 'agent6/Nutch-1.1'
     family: 'Spider'
+
+  - user_agent_string: 'Python-urllib/2.6'
+    family: 'Automata'
+
+  - user_agent_string: 'libwww-perl/5.834'
+    family: 'Automata'
+
+  - user_agent_string: 'Java/1.8.0_20'
+    family: 'Automata'
+
+  - user_agent_string: 'Apache-HttpClient/4.3.3 (java 1.5)'
+    family: 'Automata'
+
+  - user_agent_string: 'Jakarta Commons-HttpClient/3.16'
+    family: 'Automata'
+
+  - user_agent_string: 'Twisted PageGetter'
+    family: 'Automata'
+
+  - user_agent_string: 'Mozilla/4.5 (compatible; HTTrack 3.0x; Windows 98)'
+    family: 'Automata'
+
+  - user_agent_string: 'Scrapy/0.22.2 (+http://scrapy.org)'
+    family: 'Automata'
+
+  - user_agent_string: 'WordPress/3.3.2; http://givemecupcakes.com'
+    family: 'Automata'
+
+  - user_agent_string: 'Wget/1.12 (linux-gnu)'
+    family: 'Automata'


### PR DESCRIPTION
There are a lot of spiders out there, and we do our best to detect them. There are also a lot of things which, while not spiders, are also not human traffic. This may have an impact if ua-parser is being used to decide how sites display, but /definitely/ has an impact if it's being used for research and analytics purposes.

This seeks to add a new device marking, "Reuser", that applies to these. I've started with a basic list of "obvious libraries and reusers I could pick out of my logs", and associated tests. 
