### PR TITLE
removed cpp from nodejs package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+/cpp
 /csharp
 /d
 /go


### PR DESCRIPTION
Just adding the `cpp` directory to the `.npmignore` file so it's excluded when the package is created since it ships extra code that isn't needed.
