### PR TITLE
Update regexes.yaml to detect Windows 10

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -630,6 +630,9 @@ os_parsers:
     os_replacement: 'Windows RT 8.1'
   - regex: '(Windows NT 6\.3)'
     os_replacement: 'Windows 8.1'
+    
+  - regex: '(Windows NT 6\.4)'
+    os_replacement: 'Windows 10'
 
   - regex: '(Windows NT 5\.0)'
     os_replacement: 'Windows 2000'

--- a/test_resources/test_user_agent_parser_os.yaml
+++ b/test_resources/test_user_agent_parser_os.yaml
@@ -721,6 +721,13 @@ test_cases:
     patch:
     patch_minor:
 
+ - user_agent_string: 'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko'
+    family: 'Windows 8.1'
+    major:
+    minor:
+    patch:
+    patch_minor:
+    
   - user_agent_string: 'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko'
     family: 'Windows 8.1'
     major:

--- a/test_resources/test_user_agent_parser_os.yaml
+++ b/test_resources/test_user_agent_parser_os.yaml
@@ -721,8 +721,8 @@ test_cases:
     patch:
     patch_minor:
 
- - user_agent_string: 'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko'
-    family: 'Windows 8.1'
+ - user_agent_string: 'Mozilla/5.0 (Windows NT 6.4; WOW64; Trident/7.0; rv:11.0) like Gecko'
+    family: 'Windows 10'
     major:
     minor:
     patch:

--- a/test_resources/test_user_agent_parser_os.yaml
+++ b/test_resources/test_user_agent_parser_os.yaml
@@ -721,7 +721,7 @@ test_cases:
     patch:
     patch_minor:
 
- - user_agent_string: 'Mozilla/5.0 (Windows NT 6.4; WOW64; Trident/7.0; rv:11.0) like Gecko'
+  - user_agent_string: 'Mozilla/5.0 (Windows NT 6.4; WOW64; Trident/7.0; rv:11.0) like Gecko'
     family: 'Windows 10'
     major:
     minor:


### PR DESCRIPTION
As of now, the technical previews are using Windows NT 6.4, so thought of adding this.