### PR TITLE
Add RivalIQ.com bot

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -134,7 +134,7 @@ user_agent_parsers:
     family_replacement: 'NetFront'
   - regex: '(PlayStation Vita)'
     family_replacement: 'NetFront NX'
-  
+
   - regex: 'AppleWebKit.+ (NX)/(\d+)\.(\d+)\.(\d+)'
     family_replacement: 'NetFront NX'
   - regex: '(Nintendo 3DS)'
@@ -227,6 +227,10 @@ user_agent_parsers:
   # AOL Browser (IE-based)
   - regex: '(AOL) (\d+)\.(\d+); AOLBuild (\d+)'
 
+  # Rival IQ PhantomJS based bot
+  - regex: '(Rival IQ, rivaliq.com)'
+    family_replacement: 'Rival IQ'
+
   #### END SPECIAL CASES TOP ####
 
   #### MAIN CASES - this catches > 50% of all browsers ####
@@ -259,7 +263,7 @@ user_agent_parsers:
   # Chrome/Chromium/major_version.minor_version.beta_version
   - regex: '(Chromium|Chrome)/(\d+)\.(\d+)\.(\d+)'
 
-  # Dolphin Browser 
+  # Dolphin Browser
   # @ref: http://www.dolphin.com
   - regex: '\b(Dolphin)(?: |HDCN/|/INT\-)(\d+)\.(\d+)\.?(\d+)?'
 
@@ -276,11 +280,11 @@ user_agent_parsers:
   # Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 920; Orange)...
   # Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 920; Vodafone)...
   ##########
-  
+
   # IE Mobile
   - regex: '(IEMobile)[ /](\d+)\.(\d+)'
     family_replacement: 'IE Mobile'
-  
+
   # Browser major_version.minor_version.beta_version (space instead of slash)
   - regex: '(iRider|Crazy Browser|SkipStone|iCab|Lunascape|Sleipnir|Maemo Browser) (\d+)\.(\d+)\.(\d+)'
   # Browser major_version.minor_version (space instead of slash)
@@ -363,7 +367,7 @@ user_agent_parsers:
     family_replacement: 'Mobile Safari'
 
   - regex: '(AvantGo) (\d+).(\d+)'
-  
+
   - regex: '(OneBrowser)/(\d+).(\d+)'
     family_replacement: 'ONE Browser'
 
@@ -450,7 +454,7 @@ user_agent_parsers:
 
   - regex: '(Teleca)'
     family_replacement: 'Teleca Browser'
-    
+
   - regex: '(Phantom)/V(\d+)\.(\d+)'
     family_replacement: 'Phantom Browser'
 
@@ -458,7 +462,7 @@ user_agent_parsers:
     family_replacement: 'IE'
 
   # Espial
-  - regex: '(Espial)/(\d+)(?:\.(\d+))?(?:\.(\d+))?'  
+  - regex: '(Espial)/(\d+)(?:\.(\d+))?(?:\.(\d+))?'
 
  # Apple Mail
 
@@ -552,7 +556,7 @@ os_parsers:
   # can actually detect rooted android os. do we care?
   ##########
   - regex: '(Android)[ \-/](\d+)\.(\d+)(?:[.\-]([a-z0-9]+))?'
- 
+
   - regex: '(Android) Donut'
     os_v1_replacement: '1'
     os_v2_replacement: '2'
@@ -743,7 +747,7 @@ os_parsers:
     os_replacement: 'iOS'
     os_v1_replacement: '8'
     os_v2_replacement: '0.b5'
-  
+
   ##########
   # CFNetwork iOS Apps
   # @ref: https://en.wikipedia.org/wiki/Darwin_(operating_system)#Release_history
@@ -920,29 +924,29 @@ device_parsers:
   # Samsung
   - regex: '(SamsungSGHi560)'
     device_replacement: 'Samsung SGHi560'
-   
+
   - regex: '(SCH-[A-Za-z0-9_-]+)'
     device_replacement: 'Samsung $1'
-    
+
   - regex: '(SGH-[A-Za-z0-9_-]+)'
-    device_replacement: 'Samsung $1'  
-  
+    device_replacement: 'Samsung $1'
+
   - regex: '(GT-[A-Za-z0-9_-]+)'
-    device_replacement: 'Samsung $1'    
+    device_replacement: 'Samsung $1'
 
   - regex: '(SM-[A-Za-z0-9_-]+)'
-    device_replacement: 'Samsung $1'  
+    device_replacement: 'Samsung $1'
 
   - regex: '(SPH-[A-Za-z0-9_-]+)'
-    device_replacement: 'Samsung $1'  
+    device_replacement: 'Samsung $1'
 
   - regex: 'SAMSUNG-([A-Za-z0-9_-]+)'
-    device_replacement: 'Samsung $1'  
+    device_replacement: 'Samsung $1'
 
   - regex: 'SAMSUNG ([A-Za-z0-9_-]+)'
-    device_replacement: 'Samsung $1'  
-    
-    
+    device_replacement: 'Samsung $1'
+
+
   #########
   # Ericsson - must come before nokia since they also use symbian
   #########
@@ -956,7 +960,7 @@ device_parsers:
   - regex: 'PLAYSTATION 3'
     device_replacement: 'PlayStation 3'
   - regex: '(PlayStation (:?Portable|Vita))'
-  - regex: '(PlayStation (:?\d+))'  
+  - regex: '(PlayStation (:?\d+))'
 
   ##########
   # incomplete!
@@ -985,8 +989,8 @@ device_parsers:
   - regex: '(Kindle)'
   - regex: '(Silk)/(\d+)\.(\d+)(?:\.([0-9\-]+))?'
     device_replacement: 'Kindle Fire'
-      
- 
+
+
 
   ##########
   # NOKIA
@@ -1055,7 +1059,7 @@ device_parsers:
 
   - regex: 'AdsBot-Google-Mobile'
     device_replacement: 'Spider'
-   
+
   - regex: 'Googlebot-Mobile/(\d+).(\d+)'
     device_replacement: 'Spider'
 
@@ -1064,7 +1068,7 @@ device_parsers:
 
   - regex: 'NING/(\d+).(\d+)'
     device_replacement: 'Spider'
-    
+
   - regex: 'MsnBot-Media /(\d+).(\d+)'
     device_replacement: 'Spider'
 
@@ -1089,7 +1093,7 @@ device_parsers:
   - regex: 'acer_([A-Za-z0-9]+)_'
     device_replacement: 'Acer $1'
 
-  ##########   
+  ##########
   # Alcatel
   ##########
   - regex: 'ALCATEL-([A-Za-z0-9]+)'
@@ -1230,7 +1234,7 @@ device_parsers:
     device_replacement: 'Motorola $1'
   - regex: ' (DROID2| )'
     device_replacement: 'Motorola $1'
-    
+
   ##########
   # nintendo
   ##########
@@ -1244,7 +1248,7 @@ device_parsers:
   ##########
   - regex: 'Pantech([A-Za-z0-9]+)'
     device_replacement: 'Pantech $1'
- 
+
   ##########
   # philips
   ##########
@@ -1260,7 +1264,7 @@ device_parsers:
     device_replacement: 'Samsung $1'
   - regex: 'SAMSUNG\; ([A-Za-z0-9\-]+)'
     device_replacement: 'Samsung $1'
- 
+
   ##########
   # ZTE
   ##########
@@ -1290,7 +1294,7 @@ device_parsers:
   ##########
   - regex: 'Sony([^ ]+) '
     device_replacement: 'Sony $1'
-    
+
   ##########
   # WebTV
   ##########
@@ -1308,7 +1312,7 @@ device_parsers:
   - regex: 'Android[\- ][\d]+\.[\d]+; ([A-Za-z0-9 _-]+) '
   - regex: 'Android[\- ][\d]+\.[\d]+\.[\d]+; [^;]+; ([A-Za-z0-9\.\/_-]+) '
   - regex: 'Android[\- ][\d]+\.[\d]+; [^;]+; ([A-Za-z0-9\.\/_-]+) '
-  
+
   ##########
   # Generic Smart Phone
   ##########
@@ -1330,6 +1334,6 @@ device_parsers:
   ##########
   # Spiders (this is hack...)
   ##########
-  - regex: '(bingbot|bot|borg|google(^tv)|yahoo|slurp|msnbot|msrbot|openbot|archiver|netresearch|lycos|scooter|altavista|teoma|gigabot|baiduspider|blitzbot|oegp|charlotte|furlbot|http%20client|polybot|htdig|ichiro|mogimogi|larbin|pompos|scrubby|searchsight|seekbot|semanticdiscovery|silk|snappy|speedy|spider|voila|vortex|voyager|zao|zeal|fast\-webcrawler|converacrawler|dataparksearch|findlinks|crawler|Netvibes|Sogou Pic Spider|ICC\-Crawler|Innovazion Crawler|Daumoa|EtaoSpider|A6\-Indexer|YisouSpider|Riddler|DBot|wsr\-agent|Xenu|SeznamBot|PaperLiBot|SputnikBot|CCBot|ProoXiBot|Scrapy|Genieo|Screaming Frog|YahooCacheSystem|CiBra|Nutch)'
+  - regex: '(bingbot|bot|borg|google(^tv)|yahoo|slurp|msnbot|msrbot|openbot|archiver|netresearch|lycos|scooter|altavista|teoma|gigabot|baiduspider|blitzbot|oegp|charlotte|furlbot|http%20client|polybot|htdig|ichiro|mogimogi|larbin|pompos|scrubby|searchsight|seekbot|semanticdiscovery|silk|snappy|speedy|spider|voila|vortex|voyager|zao|zeal|fast\-webcrawler|converacrawler|dataparksearch|findlinks|crawler|Netvibes|Sogou Pic Spider|ICC\-Crawler|Innovazion Crawler|Daumoa|EtaoSpider|A6\-Indexer|YisouSpider|Riddler|DBot|wsr\-agent|Xenu|SeznamBot|PaperLiBot|SputnikBot|CCBot|ProoXiBot|Scrapy|Genieo|Screaming Frog|YahooCacheSystem|CiBra|Nutch|Rival IQ, rivaliq.com)'
     device_replacement: 'Spider'
 


### PR DESCRIPTION
Bot/Spider identifies itself through 
```
Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9) AppleWebKit/537.71 (KHTML, like Gecko) Version/7.0 Safari/537.71 (Rival IQ, rivaliq.com)
``` 
via a PhantomJS based instance

Also, sublime auto-removed all the spaces, cleans it a bit up, but if it is a problem I'll make sure to turn it off and re-patch

Thanks, keep up the awesome work