### PR TITLE
Update regexes.yaml

### DIFF
--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1226,9 +1226,9 @@ device_parsers:
     device_replacement: 'Motorola $1'
   - regex: ' (DROID[2 ][A-Za-z0-9 ]+) '
     device_replacement: 'Motorola $1'
-  - regex: ' (Droid2| )'
+  - regex: ' (Droid[2 ])'
     device_replacement: 'Motorola $1'
-  - regex: ' (DROID2| )'
+  - regex: ' (DROID[2 ])'
     device_replacement: 'Motorola $1'
     
   ##########
@@ -1330,6 +1330,6 @@ device_parsers:
   ##########
   # Spiders (this is hack...)
   ##########
-  - regex: '(bingbot|bot|borg|google(^tv)|yahoo|slurp|msnbot|msrbot|openbot|archiver|netresearch|lycos|scooter|altavista|teoma|gigabot|baiduspider|blitzbot|oegp|charlotte|furlbot|http%20client|polybot|htdig|ichiro|mogimogi|larbin|pompos|scrubby|searchsight|seekbot|semanticdiscovery|silk|snappy|speedy|spider|voila|vortex|voyager|zao|zeal|fast\-webcrawler|converacrawler|dataparksearch|findlinks|crawler|Netvibes|Sogou Pic Spider|ICC\-Crawler|Innovazion Crawler|Daumoa|EtaoSpider|A6\-Indexer|YisouSpider|Riddler|DBot|wsr\-agent|Xenu|SeznamBot|PaperLiBot|SputnikBot|CCBot|ProoXiBot|Scrapy|Genieo|Screaming Frog|YahooCacheSystem|CiBra|Nutch)'
+  - regex: '(bingbot|bot|borg|GoogleImageProxy|google(^tv)|yahoo|slurp|msnbot|msrbot|openbot|archiver|netresearch|lycos|scooter|altavista|teoma|gigabot|baiduspider|blitzbot|oegp|charlotte|furlbot|http%20client|polybot|htdig|ichiro|mogimogi|larbin|pompos|scrubby|searchsight|seekbot|semanticdiscovery|silk|snappy|speedy|spider|Spider|voila|vortex|voyager|zao|zeal|fast\-webcrawler|converacrawler|dataparksearch|findlinks|crawler|Crawler|Netvibes|Sogou Pic Spider|ICC\-Crawler|Innovazion Crawler|Daumoa|EtaoSpider|A6\-Indexer|YisouSpider|Riddler|DBot|wsr\-agent|Xenu|SeznamBot|PaperLiBot|SputnikBot|CCBot|ProoXiBot|Scrapy|Genieo|Screaming Frog|YahooCacheSystem|CiBra|Nutch)'
     device_replacement: 'Spider'
 


### PR DESCRIPTION
Motorola block has bug where 2 continuous spaces will match with the pattern and classify it as motorola mobile. Fix is to use ' (Droid[2 ])' instead of ' (Droid2| )'
second part of diff is to classify GoogleImageProxy as crawler as google mail spoofs user agent and use GoogleImageProxy while hitting service.
