### PR TITLE
Swap from using yaml.load to yaml.safe_load for security

### DIFF
--- a/py/ua_parser/user_agent_parser.py
+++ b/py/ua_parser/user_agent_parser.py
@@ -418,7 +418,7 @@ else:
     import yaml
 
     yamlFile = open(UA_PARSER_YAML)
-    regexes = yaml.load(yamlFile)
+    regexes = yaml.safe_load(yamlFile)
     yamlFile.close()
 
 # If UA_PARSER_YAML is not specified, load regexes from regexes.json before
@@ -432,7 +432,7 @@ if regexes is None:
         import yaml
 
         yamlFile = open(yamlPath)
-        regexes = yaml.load(yamlFile)
+        regexes = yaml.safe_load(yamlFile)
         yamlFile.close()
 
 


### PR DESCRIPTION
`yaml.load` in Python allows for instantiation of arbitrary Python objects, which can cause problems if an attacker decides to replace the yaml file with something dangerous.  I did a [blog post](http://kevinlondon.com/2015/08/15/dangerous-python-functions-pt2.html) on the security risks for yaml's load function, as did [Ned Batchelder](http://nedbatchelder.com/blog/201302/war_is_peace.html) and [others](http://blog.codeclimate.com/blog/2013/01/10/rails-remote-code-execution-vulnerability-explained/). 

This swap is also being suggested for a project forked from this one at https://github.com/ua-parser/uap-python/pull/22
