### PR TITLE
Update golang os pattern rules

### DIFF
--- a/go/uaparser/os.go
+++ b/go/uaparser/os.go
@@ -35,22 +35,25 @@ func (osPattern *OsPattern) Match(line string, os *Os) {
 		} else if groupCount >= 1 {
 			os.Family = bytes[1]
 		}
+
 		if len(osPattern.OsV1Replacement) > 0 {
 			os.Major = osPattern.OsV1Replacement
 		} else if groupCount >= 2 {
 			os.Major = bytes[2]
-			if len(osPattern.OsV2Replacement) > 0 {
-				os.Minor = osPattern.OsV2Replacement
-			} else if groupCount >= 3 {
-				os.Minor = bytes[3]
-				if groupCount >= 4 {
-					os.Patch = bytes[4]
-					if groupCount >= 5 {
-						os.PatchMinor = bytes[5]
-					}
-				}
-			}
 		}
+		if len(osPattern.OsV2Replacement) > 0 {
+			os.Minor = osPattern.OsV2Replacement
+		} else if groupCount >= 3 {
+			os.Minor = bytes[3]
+
+		}
+		if groupCount >= 4 {
+			os.Patch = bytes[4]
+		}
+		if groupCount >= 5 {
+			os.PatchMinor = bytes[5]
+		}
+
 	}
 }
 

--- a/go/uaparser/os.go
+++ b/go/uaparser/os.go
@@ -2,6 +2,7 @@ package uaparser
 
 import (
 	"regexp"
+	"strings"
 )
 
 type Os struct {
@@ -26,11 +27,14 @@ func (osPattern *OsPattern) Match(line string, os *Os) {
 		groupCount := osPattern.Regexp.NumSubexp()
 
 		if len(osPattern.OsReplacement) > 0 {
-			os.Family = osPattern.OsReplacement
+			if strings.Contains(osPattern.OsReplacement, "$1") {
+				os.Family = strings.Replace(osPattern.OsReplacement, "$1", bytes[1], -1)
+			} else {
+				os.Family = osPattern.OsReplacement
+			}
 		} else if groupCount >= 1 {
 			os.Family = bytes[1]
 		}
-
 		if len(osPattern.OsV1Replacement) > 0 {
 			os.Major = osPattern.OsV1Replacement
 		} else if groupCount >= 2 {

--- a/go/uaparser/os_test.go
+++ b/go/uaparser/os_test.go
@@ -3,8 +3,9 @@ package uaparser
 import (
 	"fmt"
 	"io/ioutil"
-	"launchpad.net/goyaml"
 	"testing"
+
+	"launchpad.net/goyaml"
 )
 
 func osInitTesting(file string) []map[string]string {

--- a/go/uaparser/parser.go
+++ b/go/uaparser/parser.go
@@ -3,10 +3,11 @@ package uaparser
 import (
 	"bytes"
 	"io/ioutil"
-	"launchpad.net/goyaml"
 	"reflect"
 	"regexp"
 	"sync"
+
+	"launchpad.net/goyaml"
 )
 
 type Parser struct {

--- a/go/uaparser/user_agent_test.go
+++ b/go/uaparser/user_agent_test.go
@@ -3,8 +3,9 @@ package uaparser
 import (
 	"fmt"
 	"io/ioutil"
-	"launchpad.net/goyaml"
 	"testing"
+
+	"launchpad.net/goyaml"
 )
 
 func uaInitTesting(file string) []map[string]string {


### PR DESCRIPTION
For golang, on the basis of the failures of testcase, we update the osParser module, including "$1" error, and overall attributes support.

Details see message of these commits.
